### PR TITLE
refactor: update cross-section properties

### DIFF
--- a/FEALiTE2D/CrossSections/CircularSection.cs
+++ b/FEALiTE2D/CrossSections/CircularSection.cs
@@ -37,8 +37,8 @@ namespace FEALiTE2D.CrossSections
         private void SetSectionProperties(double d)
         {
             this.A = PI * d * d / 4.0;
-            this.Ay = this.Ax = this.A * 0.9;
-            this.Iy = this.Ix = PI * d * d * d * d / 64.0;
+            this.Ay = this.Az = this.A * 0.9;
+            this.Iy = this.Iz = PI * d * d * d * d / 64.0;
             this.J = 0.5 * this.Iy;
             base.MaxWidth = base.MaxHeight = d;
         }

--- a/FEALiTE2D/CrossSections/Generic2DSection.cs
+++ b/FEALiTE2D/CrossSections/Generic2DSection.cs
@@ -13,20 +13,20 @@ namespace FEALiTE2D.CrossSections
         /// Creates a new instance of the <see cref="Generic2DSection"/>
         /// </summary>
         /// <param name="A">Cross section area.</param>
-        /// <param name="Ax">Shear area in x-x direction.</param>
+        /// <param name="Az">Shear area in z-z direction.</param>
         /// <param name="Ay">Shear area in y-y direction.</param>
-        /// <param name="Ix">Area moment of inertia about x axis.</param>
+        /// <param name="Iz">Area moment of inertia about z axis.</param>
         /// <param name="Iy">Area moment of inertia about y axis.</param>
         /// <param name="J">Torsional constant.</param>
         /// <param name="hmax">max. height.</param>
         /// <param name="wmax">max. width.</param>
         /// <param name="material">material.</param>
-        public Generic2DSection(double A, double Ax, double Ay, double Ix, double Iy, double J, double hmax, double wmax, IMaterial material) : base()
+        public Generic2DSection(double A, double Az, double Ay, double Iz, double Iy, double J, double hmax, double wmax, IMaterial material) : base()
         {
             base.A = A;
-            base.Ax = Ax;
+            base.Az = Az;
             base.Ay = Ay;
-            base.Ix = Ix;
+            base.Iz = Iz;
             base.Iy = Iy;
             base.J = J;
             base.MaxHeight = hmax;

--- a/FEALiTE2D/CrossSections/HollowTube.cs
+++ b/FEALiTE2D/CrossSections/HollowTube.cs
@@ -47,9 +47,9 @@ namespace FEALiTE2D.CrossSections
         {
             double di = d - 2 * t;
             this.A = 0.25 * PI * (d * d - di * di);
-            this.Ay = this.Ax = this.A * 0.5;
+            this.Ay = this.Az = this.A * 0.5;
             this.Iy = this.Iy = PI * Pow(d / 2, 3) * t;
-            this.J = Iy + Ix;
+            this.J = Iy + Iz;
             base.MaxWidth = base.MaxHeight = d;
         }       
     }

--- a/FEALiTE2D/CrossSections/IFrame2DSection.cs
+++ b/FEALiTE2D/CrossSections/IFrame2DSection.cs
@@ -23,9 +23,9 @@ namespace FEALiTE2D.CrossSections
         public double A { get; set; }
 
         /// <summary>
-        /// Shear area of the cross section in x-x direction.
+        /// Shear area of the cross section in z-z direction.
         /// </summary>
-        public virtual double Ax { get; set; }
+        public virtual double Az { get; set; }
 
         /// <summary>
         /// Shear area of the cross section in y-y direction.
@@ -33,9 +33,9 @@ namespace FEALiTE2D.CrossSections
         public virtual double Ay { get; set; }
 
         /// <summary>
-        /// Area moment of inertia about x axis.
+        /// Area moment of inertia about z axis.
         /// </summary>
-        public virtual double Ix { get; set; }
+        public virtual double Iz { get; set; }
 
         /// <summary>
         /// Area moment of inertia about y axis.

--- a/FEALiTE2D/CrossSections/IPESection.cs
+++ b/FEALiTE2D/CrossSections/IPESection.cs
@@ -70,8 +70,8 @@ namespace FEALiTE2D.CrossSections
         {
             base.A = 2 * tf * b + (h - 2 * tf) * tw + (4 - Math.PI) * r * r;
             base.Ay = base.A - 2 * b * tf + (tw + 2 * r) * tf;
-            base.Ax = 0.6667 * b * tf;
-            base.Ix = (b * h * h * h - (b - tw) * Math.Pow((h - 2 * tf), 3)) / 12 + 0.03 * Math.Pow(r, 4) + 0.2146 * r * r * Math.Pow((h - 2 * tf - 0.4468 * r), 2);
+            base.Az = 0.6667 * b * tf;
+            base.Iz = (b * h * h * h - (b - tw) * Math.Pow((h - 2 * tf), 3)) / 12 + 0.03 * Math.Pow(r, 4) + 0.2146 * r * r * Math.Pow((h - 2 * tf - 0.4468 * r), 2);
             base.Iy = (2 * tf * b * b * b + (h - 2 * tf) * tw * tw * tw) / 12 + 0.03 * Math.Pow(r, 4) + 0.2146 * r * r * Math.Pow((tw + 0.4468 * r), 2);
             base.J = 0.6667 * (b - 0.63 * tf) * tf * tf * tf + (h - 2 * tf) * tw * tw * tw / 3 + 2 * (tw / tf) * (0.145 + 0.1 * r * tf) * Math.Pow(
                 (Math.Pow(r + tw / 2, 2) + Math.Pow(r + tf, 2) - r * r) / (2 * r + tf)

--- a/FEALiTE2D/CrossSections/RectangularSection.cs
+++ b/FEALiTE2D/CrossSections/RectangularSection.cs
@@ -44,8 +44,8 @@ namespace FEALiTE2D.CrossSections
         private void SetSectionProperties(double b, double t)
         {
             this.A = b * t;
-            this.Ay = this.Ax = this.A * 5.0 / 6.0;
-            this.Ix = b * t * t * t / 12.0;
+            this.Ay = this.Az = this.A * 5.0 / 6.0;
+            this.Iz = b * t * t * t / 12.0;
             this.Iy = b * b * b * t / 12.0;
             double _t = Max(b, t);
             double _b = Min(b, t);

--- a/FEALiTE2D/Elements/FrameElement2D.cs
+++ b/FEALiTE2D/Elements/FrameElement2D.cs
@@ -150,8 +150,8 @@ namespace FEALiTE2D.Elements
         {
             DenseMatrix D = new DenseMatrix(3, 3);
             D[0, 0] = CrossSection.A * CrossSection.Material.E;
-            D[1, 1] = CrossSection.Ax * CrossSection.Material.G;
-            D[2, 2] = CrossSection.Ix * CrossSection.Material.E;
+            D[1, 1] = CrossSection.Az * CrossSection.Material.G;
+            D[2, 2] = CrossSection.Iz * CrossSection.Material.E;
             return D;
         }
 
@@ -246,9 +246,9 @@ namespace FEALiTE2D.Elements
             double l2 = l * l;
             double l3 = l * l * l;
             double EAL = this.CrossSection.Material.E * this.CrossSection.A / l;
-            double EIL = this.CrossSection.Material.E * this.CrossSection.Ix / l;
-            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Ix / l2;
-            double EIL3 = this.CrossSection.Material.E * this.CrossSection.Ix / l3;
+            double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
+            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
+            double EIL3 = this.CrossSection.Material.E * this.CrossSection.Iz / l3;
 
             DenseMatrix k = new DenseMatrix(6, 6);
 
@@ -288,9 +288,9 @@ namespace FEALiTE2D.Elements
             double l2 = l * l;
             double l3 = l * l * l;
             double EAL = this.CrossSection.Material.E * this.CrossSection.A / l;
-            double EIL = this.CrossSection.Material.E * this.CrossSection.Ix / l;
-            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Ix / l2;
-            double EIL3 = this.CrossSection.Material.E * this.CrossSection.Ix / l3;
+            double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
+            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
+            double EIL3 = this.CrossSection.Material.E * this.CrossSection.Iz / l3;
 
             DenseMatrix k = new DenseMatrix(6, 6);
 
@@ -322,9 +322,9 @@ namespace FEALiTE2D.Elements
             double l2 = l * l;
             double l3 = l * l * l;
             double EAL = this.CrossSection.Material.E * this.CrossSection.A / l;
-            double EIL = this.CrossSection.Material.E * this.CrossSection.Ix / l;
-            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Ix / l2;
-            double EIL3 = this.CrossSection.Material.E * this.CrossSection.Ix / l3;
+            double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
+            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
+            double EIL3 = this.CrossSection.Material.E * this.CrossSection.Iz / l3;
 
             DenseMatrix k = new DenseMatrix(6, 6);
 

--- a/FEALiTE2D/Meshing/LinearMeshSegment.cs
+++ b/FEALiTE2D/Meshing/LinearMeshSegment.cs
@@ -25,7 +25,7 @@ namespace FEALiTE2D.Meshing
                             Displacement2;  // displacement at end of  the segment.
         public double E, // modulus of elasticity of material of the cross-section at this segment.
                       A, // area of the cross-section at the segment.
-                      Ix; // second moment of inertial of the cross-section at the segment.
+                      Iz; // second moment of inertial of the cross-section at the segment.
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 
@@ -97,7 +97,7 @@ namespace FEALiTE2D.Meshing
                      - Internalforces1.Fy * x * x / 2.0
                      - wy1 * x * x * x / 6.0
                      - x * x * x * x * ((wy2 - wy1) / (x2 - x1)) / 24 // uniform and trap load.
-                ) / (E * Ix);
+                ) / (E * Iz);
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace FEALiTE2D.Meshing
                          - Internalforces1.Fy * x * x * x / 6.0
                          - wy1 * x * x * x * x / 24.0
                          - x * x * x * x * x * ((wy2 - wy1) / (x2 - x1)) / 120.0 // uniform and trap load.
-                    ) / (E * Ix)
+                    ) / (E * Iz)
                 );
         }
 

--- a/FEALiTE2D/Meshing/LinearMesher.cs
+++ b/FEALiTE2D/Meshing/LinearMesher.cs
@@ -124,7 +124,7 @@ namespace FEALiTE2D.Meshing
                 if (!(element is SpringElement2D))
                 {
                     segment.E = element.CrossSection.Material.E;
-                    segment.Ix = element.CrossSection.Ix;
+                    segment.Iz = element.CrossSection.Iz;
                     segment.A = element.CrossSection.A;
                 }
 

--- a/FEALiTE2D/Structure/PostProcessor.cs
+++ b/FEALiTE2D/Structure/PostProcessor.cs
@@ -398,7 +398,7 @@ namespace FEALiTE2D.Structure
                 temp.x1 = cSegment.x1;
                 temp.x2 = cSegment.x2;
                 temp.A = cSegment.A;
-                temp.Ix = cSegment.Ix;
+                temp.Iz = cSegment.Iz;
                 temp.E = cSegment.E;
                 list.Add(temp);
             }


### PR DESCRIPTION
Update cross-section properties and summaries to use Az and Iz instead of Ax and Ix, acc. to the chosen coordinate system.
Indeed, the x axis is supposed to represent the main axis of the element, the y axis the "vertical" one, and the z axis is the "off-plan" axis.

So, there is no way that Ix and Ax have sense here. This is a confusion between x and z.
Changing names will lead to build errors for the projects that use FEALITE2D, but the fix is easy, and the codebase is at least coherent.

---
PS: I did not run the unit tests, as i am currently unable to run NUnit tests, sorry for the inconvenience