### PR TITLE
Performance optimisations and naming consistency

### DIFF
--- a/FEALiTE2D.Tests/Elements/FrameElement2DTestTandK.cs
+++ b/FEALiTE2D.Tests/Elements/FrameElement2DTestTandK.cs
@@ -17,7 +17,7 @@ namespace FEALiTE2D.Tests.Elements
         FrameElement2D e1;
         FrameElement2D e2;
         IMaterial material;
-        IFrame2DSection section;
+        Frame2DSection section;
 
         [SetUp]
         public void Setup()

--- a/FEALiTE2D.Tests/Loads/FrameLinearLoadTest.cs
+++ b/FEALiTE2D.Tests/Loads/FrameLinearLoadTest.cs
@@ -18,7 +18,7 @@ namespace FEALiTE2D.Tests.Loads
         Node2D n2;
         FrameElement2D e1;
         IMaterial material;
-        IFrame2DSection section;
+        Frame2DSection section;
 
         [SetUp]
         public void Setup()

--- a/FEALiTE2D.Tests/Loads/FramePointLoadTest.cs
+++ b/FEALiTE2D.Tests/Loads/FramePointLoadTest.cs
@@ -16,7 +16,7 @@ namespace FEALiTE2D.Tests.Loads
         Node2D n2;
         FrameElement2D e1;
         IMaterial material;
-        IFrame2DSection section;
+        Frame2DSection section;
 
         [SetUp]
         public void Setup()

--- a/FEALiTE2D.Tests/Meshing/LinearMesherTest.cs
+++ b/FEALiTE2D.Tests/Meshing/LinearMesherTest.cs
@@ -17,7 +17,7 @@ namespace FEALiTE2D.Tests.Meshing
         {
             FEALiTE2D.Structure.Structure structure = new FEALiTE2D.Structure.Structure();
             IMaterial material = new GenericIsotropicMaterial() { E = 30E6, U = 0.2, Label = "Steel", Alpha = 0.000012, Gama = 39885, MaterialType = MaterialType.Steel };
-            IFrame2DSection section = new Generic2DSection(0.075, 0.075, 0.075, 0.000480, 0.000480, 0.000480 * 2, 0.1, 0.1, material);
+            Frame2DSection section = new Generic2DSection(0.075, 0.075, 0.075, 0.000480, 0.000480, 0.000480 * 2, 0.1, 0.1, material);
 
             structure.LinearMesher = new LinearMesher(10, 1);
             Node2D n1 = new Node2D(0, 0, "n1");

--- a/FEALiTE2D.Tests/Structure/PostProcessorTest.cs
+++ b/FEALiTE2D.Tests/Structure/PostProcessorTest.cs
@@ -77,7 +77,7 @@ namespace FEALiTE2D.Tests.Structure
             
             _elem.Loads.Add(new FrameUniformLoad(0.0, w, LoadDirection.Local, _lc, a, c));
             
-            _structure.LinearMesher.NumberSegements = 4;
+            _structure.LinearMesher.NumberSegments = 4;
             _structure.Solve();
             
             var postProcessor = _structure.Results;

--- a/FEALiTE2D.Tests/Structure/StructureTest.cs
+++ b/FEALiTE2D.Tests/Structure/StructureTest.cs
@@ -52,7 +52,7 @@ namespace FEALiTE2D.Tests.Structure
             n5.NodalLoads.Add(new NodalLoad(40, 0, 0, LoadDirection.Global, loadCase));
             n1.NodalLoads.Add(new NodalLoad(40, 0, 0, LoadDirection.Global, loadCase));
 
-            structure.LinearMesher.NumberSegements = 35;
+            structure.LinearMesher.NumberSegments = 35;
             structure.Solve();
 
             var nd1 = structure.Results.GetNodeGlobalDisplacement(n1, loadCase);
@@ -114,7 +114,7 @@ namespace FEALiTE2D.Tests.Structure
             e2.Loads.Add(new FrameUniformLoad(0, -0.125, LoadDirection.Global, loadCase, 0, 0));
             n2.NodalLoads.Add(new NodalLoad(0, 0, -1500, LoadDirection.Global, loadCase));
             structure.LoadCasesToRun.Add(loadCase);
-            structure.LinearMesher.NumberSegements = 50;
+            structure.LinearMesher.NumberSegments = 50;
             structure.Solve();
 
             Assert.AreEqual(structure.Results.GetSupportReaction(n1, loadCase), Force.FromVector(new double[] { 30.37225194999335, 102.08675797670341, 1215.9664523968904 }));
@@ -283,7 +283,7 @@ namespace FEALiTE2D.Tests.Structure
             n2.NodalLoads.Add(new NodalLoad(0, -200, 0, LoadDirection.Global, loadCase));
             n3.NodalLoads.Add(new NodalLoad(0, 0, -90, LoadDirection.Global, loadCase));
 
-            structure.LinearMesher.NumberSegements = 20;
+            structure.LinearMesher.NumberSegments = 20;
             structure.Solve();
 
             var R1 = structure.Results.GetSupportReaction(n1, loadCase);
@@ -347,7 +347,7 @@ namespace FEALiTE2D.Tests.Structure
             //e2.Loads.Add(new FrameUniformLoad(0, -7.5, LoadDirection.Global, loadCase));
             e1.Loads.Add(new FrameTrapezoidalLoad(100, 0, -13.5, -5.5, LoadDirection.Global, loadCase, 1.35));
 
-            structure.LinearMesher.NumberSegements = 10;
+            structure.LinearMesher.NumberSegments = 10;
             structure.Solve();
 
             var MeshSegments = structure.Results.GetElementInternalForces(e1, loadCase);
@@ -485,7 +485,7 @@ namespace FEALiTE2D.Tests.Structure
             e1.Loads.Add(new FrameUniformLoad(0, -3.5, LoadDirection.Global, loadCase));
             e2.Loads.Add(new FramePointLoad(0, -6, 0, 2, LoadDirection.Global, loadCase));
 
-            structure.LinearMesher.NumberSegements = 50;
+            structure.LinearMesher.NumberSegments = 50;
             structure.Solve();
 
             var nd1 = structure.Results.GetNodeGlobalDisplacement(n1, loadCase);
@@ -679,7 +679,7 @@ namespace FEALiTE2D.Tests.Structure
 
             n2.NodalLoads.Add(new NodalLoad(20, 0, 0, LoadDirection.Global, DeadLoadCase));
 
-            structure.LinearMesher.NumberSegements = 30;
+            structure.LinearMesher.NumberSegments = 30;
             structure.Solve();
 
             var op = new Plotting.Dxf.PlottingOption
@@ -787,7 +787,7 @@ namespace FEALiTE2D.Tests.Structure
             e2.Loads.Add(new FrameUniformLoad(0.0, -0.8, LoadDirection.Global, loadCase));
             e3.Loads.Add(new FrameUniformLoad(0.0, -0.8, LoadDirection.Local, loadCase));
             e4.Loads.Add(new FrameUniformLoad(0.0, -0.8, LoadDirection.Global, loadCase));
-            structure.LinearMesher.NumberSegements = 20;
+            structure.LinearMesher.NumberSegments = 20;
 
             structure.Solve();
 

--- a/FEALiTE2D.Tests/Structure/StructureTest.cs
+++ b/FEALiTE2D.Tests/Structure/StructureTest.cs
@@ -33,7 +33,7 @@ namespace FEALiTE2D.Tests.Structure
 
             structure.AddNode(n1, n2, n3, n4, n5);
             IMaterial material = new GenericIsotropicMaterial() { E = 30E6, U = 0.2, Label = "Steel", Alpha = 0.000012, Gama = 39885, MaterialType = MaterialType.Steel };
-            IFrame2DSection section = new Generic2DSection(0.075, 0.075, 0.075, 0.000480, 0.000480, 0.000480 * 2, 0.1, 0.1, material);
+            Frame2DSection section = new Generic2DSection(0.075, 0.075, 0.075, 0.000480, 0.000480, 0.000480 * 2, 0.1, 0.1, material);
 
             FrameElement2D e1 = new FrameElement2D(n1, n3, "e1") { CrossSection = section };
             FrameElement2D e2 = new FrameElement2D(n2, n4, "e2") { CrossSection = section };
@@ -103,7 +103,7 @@ namespace FEALiTE2D.Tests.Structure
 
             structure.AddNode(n1, n2, n3);
             IMaterial material = new GenericIsotropicMaterial() { E = 29E3, U = 0.2, Label = "Concrete", Alpha = 0.000012, Gama = 24.53, MaterialType = MaterialType.Concrete };
-            IFrame2DSection section = new Generic2DSection(11.8, 11.8, 11.8, 310, 310, 310 * 2, 0.1, 0.1, material);
+            Frame2DSection section = new Generic2DSection(11.8, 11.8, 11.8, 310, 310, 310 * 2, 0.1, 0.1, material);
 
             FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = section };
             FrameElement2D e2 = new FrameElement2D(n2, n3, "e2") { CrossSection = section };
@@ -187,7 +187,7 @@ namespace FEALiTE2D.Tests.Structure
 
             structure.AddNode(n1, n2, n3);
             IMaterial material = new GenericIsotropicMaterial() { E = 29E3, U = 0.2, Label = "Concrete", Alpha = 0.000012, Gama = 24.53, MaterialType = MaterialType.Concrete };
-            IFrame2DSection section = new Generic2DSection(11.8, 11.8, 11.8, 310, 310, 310 * 2, 0.1, 0.1, material);
+            Frame2DSection section = new Generic2DSection(11.8, 11.8, 11.8, 310, 310, 310 * 2, 0.1, 0.1, material);
 
             FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = section };
             FrameElement2D e2 = new FrameElement2D(n2, n3, "e2") { CrossSection = section };
@@ -268,8 +268,8 @@ namespace FEALiTE2D.Tests.Structure
 
             structure.AddNode(n1, n2, n3, n4);
             IMaterial material = new GenericIsotropicMaterial() { E = 28E6, U = 0.2, MaterialType = MaterialType.Concrete };
-            IFrame2DSection section1 = new Generic2DSection(0.03228, 0.03228, 0.03228, 0.0058, 0.0058, 0, 0, 0, material);
-            IFrame2DSection section2 = new Generic2DSection(1.5 * 0.03228, 1.5 * 0.03228, 1.5 * 0.1634, 1.5 * 0.0058, 1.5 * 0.0058, 0, 0, 0, material);
+            Frame2DSection section1 = new Generic2DSection(0.03228, 0.03228, 0.03228, 0.0058, 0.0058, 0, 0, 0, material);
+            Frame2DSection section2 = new Generic2DSection(1.5 * 0.03228, 1.5 * 0.03228, 1.5 * 0.1634, 1.5 * 0.0058, 1.5 * 0.0058, 0, 0, 0, material);
 
             FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = section2 };
             FrameElement2D e2 = new FrameElement2D(n2, n3, "e2") { CrossSection = section1 };
@@ -336,7 +336,7 @@ namespace FEALiTE2D.Tests.Structure
 
             structure.AddNode(n1, n2, n3);
             IMaterial material = new GenericIsotropicMaterial() { E = 30000000, U = 0.2, MaterialType = MaterialType.Concrete };
-            IFrame2DSection section1 = new RectangularSection(0.25, 0.75, material);
+            Frame2DSection section1 = new RectangularSection(0.25, 0.75, material);
 
             FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = section1 };
             FrameElement2D e2 = new FrameElement2D(n2, n3, "e2") { CrossSection = section1 };
@@ -474,7 +474,7 @@ namespace FEALiTE2D.Tests.Structure
 
             structure.AddNode(n1, n2, n3);
             IMaterial material = new GenericIsotropicMaterial() { E = 30000000, U = 0.2, MaterialType = MaterialType.Concrete };
-            IFrame2DSection section1 = new RectangularSection(0.25, 0.75, material);
+            Frame2DSection section1 = new RectangularSection(0.25, 0.75, material);
 
             FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = section1 };
             FrameElement2D e2 = new FrameElement2D(n2, n3, "e3") { CrossSection = section1, EndRelease = Frame2DEndRelease.StartRelease };
@@ -559,7 +559,7 @@ namespace FEALiTE2D.Tests.Structure
 
             structure.AddNode(n1, n2, n3, n1_, n2_, n3_);
             IMaterial material = new GenericIsotropicMaterial() { E = 30000000, U = 0.2, MaterialType = MaterialType.Concrete };
-            IFrame2DSection section1 = new RectangularSection(0.25, 0.75, material);
+            Frame2DSection section1 = new RectangularSection(0.25, 0.75, material);
 
             FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = section1 };
             FrameElement2D e2 = new FrameElement2D(n2, n3, "e2") { CrossSection = section1, EndRelease = Frame2DEndRelease.StartRelease };
@@ -604,7 +604,7 @@ namespace FEALiTE2D.Tests.Structure
 
             structure.AddNode(n1, n2, n3);
             IMaterial material = new GenericIsotropicMaterial() { E = 30000000, U = 0.2, MaterialType = MaterialType.Concrete };
-            IFrame2DSection section1 = new RectangularSection(0.25, 0.75, material);
+            Frame2DSection section1 = new RectangularSection(0.25, 0.75, material);
 
             FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = section1 };
             FrameElement2D e2 = new FrameElement2D(n2, n3, "e2") { CrossSection = section1, EndRelease = Frame2DEndRelease.StartRelease };
@@ -653,8 +653,8 @@ namespace FEALiTE2D.Tests.Structure
 
             structure.AddNode(n1, n2, n3, n4, n5, n6, n7, n8);
             IMaterial material = new GenericIsotropicMaterial() { E = 30E6, U = 0.2, Label = "Steel", Alpha = 0.000012, Gama = 39885, MaterialType = MaterialType.Steel };
-            IFrame2DSection Columns_Section = new CircularSection(0.4, material);
-            IFrame2DSection Beam_Section = new RectangularSection(0.4, 0.4, material);
+            Frame2DSection Columns_Section = new CircularSection(0.4, material);
+            Frame2DSection Beam_Section = new RectangularSection(0.4, 0.4, material);
 
             // columns
             FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = Columns_Section };
@@ -769,7 +769,7 @@ namespace FEALiTE2D.Tests.Structure
             structure.AddNode(n32);
 
             IMaterial material = new GenericIsotropicMaterial() { E = 205000, U = 0.3, MaterialType = MaterialType.Steel };
-            IFrame2DSection section1 = new Generic2DSection(2667, 1600, 1100 * 100, 18100000, 1, 1, 200, 100, material);  // H-200x100
+            Frame2DSection section1 = new Generic2DSection(2667, 1600, 1100 * 100, 18100000, 1, 1, 200, 100, material);  // H-200x100
 
             FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = section1 };
             FrameElement2D e2 = new FrameElement2D(n11, n12, "e2") { CrossSection = section1 };

--- a/FEALiTE2D/CrossSections/CircularSection.cs
+++ b/FEALiTE2D/CrossSections/CircularSection.cs
@@ -6,9 +6,9 @@ namespace FEALiTE2D.CrossSections
     /// <summary>
     /// Represents a Solid Circular Cross-Section.
     /// </summary>
-    /// <seealso cref="FEALiTE2D.CrossSections.IFrame2DSection" />
+    /// <seealso cref="FEALiTE2D.CrossSections.Frame2DSection" />
     [System.Serializable]
-    public class CircularSection : IFrame2DSection
+    public class CircularSection : Frame2DSection
     {
         /// <summary>
         /// Creates new instance of a <see cref="CircularSection"/>.

--- a/FEALiTE2D/CrossSections/Frame2DSection.cs
+++ b/FEALiTE2D/CrossSections/Frame2DSection.cs
@@ -3,18 +3,18 @@
 namespace FEALiTE2D.CrossSections
 {
     /// <summary>
-    /// Represents a class for <see cref="IFrame2DSection"/>.
+    /// Represents a class for <see cref="Frame2DSection"/>.
     /// </summary>
     [System.Serializable]
-    public abstract class IFrame2DSection
+    public abstract class Frame2DSection
     {
         /// <summary>
-        /// Material of the <see cref="IFrame2DSection"/>.
+        /// Material of the <see cref="Frame2DSection"/>.
         /// </summary>
         public IMaterial Material { get; set; }
 
         /// <summary>
-        /// Label of <see cref="IFrame2DSection"/>.
+        /// Label of <see cref="Frame2DSection"/>.
         /// </summary>
         public string Label { get; set; }
         /// <summary>

--- a/FEALiTE2D/CrossSections/Frame2DSection.cs
+++ b/FEALiTE2D/CrossSections/Frame2DSection.cs
@@ -55,6 +55,55 @@ namespace FEALiTE2D.CrossSections
         /// <summary>
         /// Gets or sets the maximum width.
         /// </summary>
-        public virtual double MaxWidth { get; set; }        
+        public virtual double MaxWidth { get; set; }
+
+        private double? _EIz;
+        internal double EIz
+        {
+            get
+            {
+                if (_EIz == null)
+                {
+                    _EIz = Material.E * Iz;
+                }
+                return _EIz.Value;
+            }
+        }
+        private double? _EIy;
+        internal double EIy
+        {
+            get
+            {
+                if (_EIy == null)
+                {
+                    _EIy = Material.E * Iy;
+                }
+                return _EIy.Value;
+            }
+        }
+        private double? _GAz;
+        internal double GAz
+        {
+            get
+            {
+                if (_GAz == null)
+                {
+                    _GAz = Material.G * Az;
+                }
+                return _GAz.Value;
+            }
+        }
+        private double? _EA;
+        internal double EA
+        {
+            get
+            {
+                if (_EA == null)
+                {
+                    _EA = Material.E * A;
+                }
+                return _EA.Value;
+            }
+        }    
     }
 }

--- a/FEALiTE2D/CrossSections/Generic2DSection.cs
+++ b/FEALiTE2D/CrossSections/Generic2DSection.cs
@@ -7,7 +7,7 @@ namespace FEALiTE2D.CrossSections
     /// Creates a generic section (user defined section), the user will have to give all required section properties for the section.
     /// </summary>
     [System.Serializable]
-    public class Generic2DSection : IFrame2DSection
+    public class Generic2DSection : Frame2DSection
     {
         /// <summary>
         /// Creates a new instance of the <see cref="Generic2DSection"/>

--- a/FEALiTE2D/CrossSections/HollowTube.cs
+++ b/FEALiTE2D/CrossSections/HollowTube.cs
@@ -6,9 +6,9 @@ namespace FEALiTE2D.CrossSections
     /// <summary>
     /// Represent a solid tube with hole.
     /// </summary>
-    /// <seealso cref="FEALiTE2D.CrossSections.IFrame2DSection" />
+    /// <seealso cref="FEALiTE2D.CrossSections.Frame2DSection" />
     [System.Serializable]
-    public class HollowTube : IFrame2DSection
+    public class HollowTube : Frame2DSection
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HollowTube"/> class.

--- a/FEALiTE2D/CrossSections/IPESection.cs
+++ b/FEALiTE2D/CrossSections/IPESection.cs
@@ -6,9 +6,9 @@ namespace FEALiTE2D.CrossSections
     /// <summary>
     /// Represent an European I beams section.
     /// </summary>
-    /// <seealso cref="FEALiTE2D.CrossSections.IFrame2DSection" />
+    /// <seealso cref="FEALiTE2D.CrossSections.Frame2DSection" />
     [System.Serializable]
-    public class IPESection : IFrame2DSection
+    public class IPESection : Frame2DSection
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IPESection"/> class.

--- a/FEALiTE2D/CrossSections/RectangularSection.cs
+++ b/FEALiTE2D/CrossSections/RectangularSection.cs
@@ -7,7 +7,7 @@ namespace FEALiTE2D.CrossSections
     /// Represents a Solid Rectangular Cross-Section.
     /// </summary>
     [System.Serializable]
-    public class RectangularSection : IFrame2DSection
+    public class RectangularSection : Frame2DSection
     {
         /// <summary>
         /// Creates new instance of a <see cref="RectangularSection"/>.

--- a/FEALiTE2D/Elements/FrameElement2D.cs
+++ b/FEALiTE2D/Elements/FrameElement2D.cs
@@ -61,7 +61,7 @@ namespace FEALiTE2D.Elements
         /// <summary>
         /// Cross section of the <see cref="FrameElement2D"/>.
         /// </summary>
-        public IFrame2DSection CrossSection { get; set; }
+        public Frame2DSection CrossSection { get; set; }
 
         /// <inheritdoc/>
         public double Length => Sqrt(Pow(EndNode.X - StartNode.X, 2) + Pow(EndNode.Y - StartNode.Y, 2));

--- a/FEALiTE2D/Elements/FrameElement2D.cs
+++ b/FEALiTE2D/Elements/FrameElement2D.cs
@@ -149,9 +149,9 @@ namespace FEALiTE2D.Elements
         public DenseMatrix GetConstitutiveMatrix()
         {
             DenseMatrix D = new DenseMatrix(3, 3);
-            D[0, 0] = CrossSection.A * CrossSection.Material.E;
-            D[1, 1] = CrossSection.Az * CrossSection.Material.G;
-            D[2, 2] = CrossSection.Iz * CrossSection.Material.E;
+            D[0, 0] = CrossSection.EA;
+            D[1, 1] = CrossSection.GAz;
+            D[2, 2] = CrossSection.EIz;
             return D;
         }
 

--- a/FEALiTE2D/Elements/IElement.cs
+++ b/FEALiTE2D/Elements/IElement.cs
@@ -37,7 +37,7 @@ namespace FEALiTE2D.Elements
         /// <summary>
         /// Gets or sets the cross section for this element.
         /// </summary>
-        IFrame2DSection CrossSection { get; set; }
+        Frame2DSection CrossSection { get; set; }
 
         /// <summary>
         /// Length of the member.

--- a/FEALiTE2D/Elements/SpringElement2D.cs
+++ b/FEALiTE2D/Elements/SpringElement2D.cs
@@ -89,7 +89,7 @@ namespace FEALiTE2D.Elements
 
         /// <inheritdoc/>
         [Obsolete("spring element doesn't have cross section properties.", true)]
-        public IFrame2DSection CrossSection { get; set; }
+        public Frame2DSection CrossSection { get; set; }
 
         /// <inheritdoc/>
         public double Length => Sqrt(Pow(EndNode.X - StartNode.X, 2) + Pow(EndNode.Y - StartNode.Y, 2));

--- a/FEALiTE2D/Loads/LoadCase.cs
+++ b/FEALiTE2D/Loads/LoadCase.cs
@@ -58,7 +58,7 @@
             {
                 return false;
             }
-            if (this.GetType() != typeof(LoadCase) || obj.GetType() != typeof(LoadCase))
+            if (! (this is LoadCase) || ! (obj is LoadCase))
             {
                 return false;
             }

--- a/FEALiTE2D/Loads/NodalLoad.cs
+++ b/FEALiTE2D/Loads/NodalLoad.cs
@@ -78,7 +78,7 @@ namespace FEALiTE2D.Loads
             {
                 return false;
             }
-            if (obj.GetType() != typeof(NodalLoad))
+            if (!(obj is NodalLoad))
             {
                 return false;
             }

--- a/FEALiTE2D/Loads/SupportDisplacementLoad.cs
+++ b/FEALiTE2D/Loads/SupportDisplacementLoad.cs
@@ -76,7 +76,7 @@ namespace FEALiTE2D.Loads
             {
                 return false;
             }
-            if (obj.GetType() != typeof(SupportDisplacementLoad))
+            if (!(obj is SupportDisplacementLoad))
             {
                 return false;
             }

--- a/FEALiTE2D/Meshing/ILinearMesher.cs
+++ b/FEALiTE2D/Meshing/ILinearMesher.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Gets or sets the minimum number of segments that the <see cref="Elements.IElement"/> be discretized into.
         /// </summary>
-        int NumberSegements { get; set; }
+        int NumberSegments { get; set; }
 
         /// <summary>
         /// Gets or sets the minimum length of segments that the <see cref="Elements.IElement"/> be discretized into.

--- a/FEALiTE2D/Meshing/LinearMeshSegment.cs
+++ b/FEALiTE2D/Meshing/LinearMeshSegment.cs
@@ -23,9 +23,8 @@ namespace FEALiTE2D.Meshing
         public Force Internalforces2; // internal forces at end of the segment.
         public Displacement Displacement1, // displacement at start of the segment.
                             Displacement2;  // displacement at end of  the segment.
-        public double E, // modulus of elasticity of material of the cross-section at this segment.
-                      A, // area of the cross-section at the segment.
-                      Iz; // second moment of inertial of the cross-section at the segment.
+        public double  EIz, // modulus of elasticity times second moment of inertial of the cross-section at the segment.area 
+                       EA; // modulus of elasticity times area of the cross-section at the segment.
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 
@@ -97,7 +96,7 @@ namespace FEALiTE2D.Meshing
                      - Internalforces1.Fy * x * x / 2.0
                      - wy1 * x * x * x / 6.0
                      - x * x * x * x * ((wy2 - wy1) / (x2 - x1)) / 24 // uniform and trap load.
-                ) / (E * Iz);
+                ) / (EIz);
         }
 
         /// <summary>
@@ -114,7 +113,7 @@ namespace FEALiTE2D.Meshing
                          - Internalforces1.Fy * x * x * x / 6.0
                          - wy1 * x * x * x * x / 24.0
                          - x * x * x * x * x * ((wy2 - wy1) / (x2 - x1)) / 120.0 // uniform and trap load.
-                    ) / (E * Iz)
+                    ) / (EIz)
                 );
         }
 
@@ -124,7 +123,6 @@ namespace FEALiTE2D.Meshing
         /// <param name="x">a distance</param>
         public double AxialDisplacementAt(double x)
         {
-            double EA = E * A;
             return Displacement1.Ux -
                 Internalforces1.Fx * x / EA + wx1 * x * x / (2.0 * EA) + (wx2 - wx1) * x * x * x / (6.0 * EA * (x2 - x1));
         }

--- a/FEALiTE2D/Meshing/LinearMesher.cs
+++ b/FEALiTE2D/Meshing/LinearMesher.cs
@@ -123,9 +123,8 @@ namespace FEALiTE2D.Meshing
                 // set geometric properties.
                 if (!(element is SpringElement2D))
                 {
-                    segment.E = element.CrossSection.Material.E;
-                    segment.Iz = element.CrossSection.Iz;
-                    segment.A = element.CrossSection.A;
+                       segment.EIz = element.CrossSection.EIz;
+                    segment.EA = element.CrossSection.EA;
                 }
 
                 element.MeshSegments.Add(segment);

--- a/FEALiTE2D/Meshing/LinearMesher.cs
+++ b/FEALiTE2D/Meshing/LinearMesher.cs
@@ -17,7 +17,7 @@ namespace FEALiTE2D.Meshing
         /// </summary>
         public LinearMesher()
         {
-            this.NumberSegements = 5;
+            this.NumberSegments = 5;
         }
 
         /// <summary>
@@ -28,11 +28,11 @@ namespace FEALiTE2D.Meshing
         public LinearMesher(int n, double d)
         {
             this.MinDistance = d;
-            this.NumberSegements = n;
+            this.NumberSegments = n;
         }
 
         /// <inheritdoc/>
-        public int NumberSegements { get; set; }
+        public int NumberSegments { get; set; }
 
         /// <inheritdoc/>
         public double MinDistance { get; set; }
@@ -96,15 +96,16 @@ namespace FEALiTE2D.Meshing
             // 2- add locations based on number of segments and length of the segment.
             if (element.GetType() != typeof(SpringElement2D))
             {
-                int n1 = (int)Math.Floor(len / this.MinDistance);
-                int n2 = this.NumberSegements;
-                int n = Math.Max(n1, n2);
-                double dx = len / n;
+                int n1 = (int)
+                        Math.Floor(len / (this.MinDistance == 0d ? len : this.MinDistance));
+                    int n2 = this.NumberSegments;
+                    int n = Math.Max(n1, n2);
+                    double dx = len / n;
 
-                for (int i = 0; i < n; i++)
-                {
-                    discreteLocations.Add(i * dx);
-                }
+                    for (int i = 0; i < n; i++)
+                    {
+                        discreteLocations.Add(i * dx);
+                    }
             }
 
             // add last point

--- a/FEALiTE2D/Meshing/LinearMesher.cs
+++ b/FEALiTE2D/Meshing/LinearMesher.cs
@@ -94,7 +94,7 @@ namespace FEALiTE2D.Meshing
             }
 
             // 2- add locations based on number of segments and length of the segment.
-            if (element.GetType() != typeof(SpringElement2D))
+            if (!(element is SpringElement2D))
             {
                 int n1 = (int)
                         Math.Floor(len / (this.MinDistance == 0d ? len : this.MinDistance));

--- a/FEALiTE2D/Structure/PostProcessor.cs
+++ b/FEALiTE2D/Structure/PostProcessor.cs
@@ -397,9 +397,8 @@ namespace FEALiTE2D.Structure
                 var cSegment = element.MeshSegments[i];
                 temp.x1 = cSegment.x1;
                 temp.x2 = cSegment.x2;
-                temp.A = cSegment.A;
-                temp.Iz = cSegment.Iz;
-                temp.E = cSegment.E;
+                temp.EIz = cSegment.EIz;
+                temp.EA = cSegment.EA;
                 list.Add(temp);
             }
 

--- a/FEALiTE2D/Structure/Structure.cs
+++ b/FEALiTE2D/Structure/Structure.cs
@@ -84,6 +84,8 @@ namespace FEALiTE2D.Structure
         /// </summary>
         public FEALiTE2D.Meshing.ILinearMesher LinearMesher { get; set; }
 
+        private static bool CopyrightDisplayed = false; 
+        
         /// <summary>
         /// Adds a node to the structure, We check if the node is already added to avoid duplicate nodes.
         /// </summary>
@@ -214,14 +216,23 @@ namespace FEALiTE2D.Structure
         /// <summary>
         /// Solve the structure.
         /// </summary>
-        public void Solve()
+        public void Solve(bool detailedAnalysisOutput = true)
         {
-            Console.WriteLine(" ================= FEALiTE Analysis Solver ================= ");
-            Console.WriteLine(" FEALiTE2D V1.0.0 - Copyright (C) 2021 Mohamed S. Ibrahim");
-            Console.WriteLine(" Linear Analysis of 1D structures.");
-            Console.WriteLine($" Analysis Start: {DateTime.Now}.");
+            if (!CopyrightDisplayed)
+            {
+                Console.WriteLine(" ================= FEALiTE Analysis Solver ================= ");
+                Console.WriteLine(" FEALiTE2D V1.0.0 - Copyright (C) 2021 Mohamed S. Ibrahim");
+                Console.WriteLine(" Linear Analysis of 1D structures.");
+                CopyrightDisplayed = true;
+            }
 
-            System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+            System.Diagnostics.Stopwatch sw = null;
+            if (detailedAnalysisOutput)
+            {
+
+                Console.WriteLine($" Analysis Start: {DateTime.Now}.");
+                 sw = System.Diagnostics.Stopwatch.StartNew();
+            }
 
             if (this.LoadCasesToRun.Count <= 0)
             {
@@ -270,10 +281,13 @@ namespace FEALiTE2D.Structure
 
             AnalysisStatus = AnalysisStatus.Successful;
 
-            sw.Stop();
-            Console.WriteLine($" No. of Equations: {this.nDOF}");
-            Console.WriteLine($" Analysis End Date: {DateTime.Now}.");
-            Console.WriteLine($" Analysis Took {sw.Elapsed.TotalSeconds} sec.");
+            if (detailedAnalysisOutput)
+            {
+               sw.Stop();
+               Console.WriteLine($" No. of Equations: {this.nDOF}");
+               Console.WriteLine($" Analysis End Date: {DateTime.Now}.");
+               Console.WriteLine($" Analysis Took {sw.Elapsed.TotalSeconds} sec.");
+            }
 
             this.Results = new PostProcessor(this);
             this.SetUpMeshingSegments();


### PR DESCRIPTION
Hello,

This pull request is mainly focused on performance improvements.

Even though the commit messages should be explicit, here are some detailed explanations, point by point:

- The properties `EIz`, `GAz`, and `EA `were previously recalculated each time they were accessed. For a (marginal) performance gain, I implemented proper getters with caching, so these values are now computed only once and then reused.
- If `LinearMesher.MinDistance` is not manually set to a >0 value, the post processor will end into an inifite loop. It is tricky to debug and to figure out where the probelem comes from. So I added a small fix that bypass the use of the `LinearMesher.MinDistance` in case is equals 0.
- The `.GetType()` method was used in several places to check types, but this approach is not convenient when dealing with inheritance. I replaced these checks with the `is` operator, which preserves the logic and also works correctly with inherited classes.
- The console log displaying analysis details (such as computation time) can be useful for debugging or for one-off FEM solving. However, for larger applications involving many solves, it provides little value and negatively impacts performance. The `Structure.Solve()` method now has an optional argument to disable this analysis output.
- Finally, I added a static field to the `Structure` class so that the copyright disclaimer is displayed only once, regardless of the number of `Structure `instances. This preserves the disclaimer while optimizing performance.
I hope these improvements make sense. I am happy to discuss any questions you may have.

Regards,