### PR TITLE
Timoshenko beam theory & bug fixes

### DIFF
--- a/FEALiTE2D.Plotting/Dxf/Plotter.cs
+++ b/FEALiTE2D.Plotting/Dxf/Plotter.cs
@@ -635,7 +635,7 @@ namespace FEALiTE2D.Plotting.Dxf
             {
                 Layer = PlottingOption.LayerOfDisplacement,
                 Height = 0.01 * boundingRectangle.Width,
-                Value = $"Bending Moment Diagram - {loadCase.Label}",
+                Value = $"Displacement Diagram - {loadCase.Label}",
                 AttachmentPoint = netDxf.Entities.MTextAttachmentPoint.MiddleCenter,
                 Position = new Vector3(startPosition.X + boundingRectangle.Width / 2.0, startPosition.Y, 0)
             };
@@ -694,10 +694,10 @@ namespace FEALiTE2D.Plotting.Dxf
         private netDxf.BoundingRectangle BoundingRectangle()
         {
             List<Vector2> allPoints = new List<Vector2>(this.Structure.Nodes.Count);
-            Parallel.ForEach(this.Structure.Nodes, (n) =>
+            foreach (var n in this.Structure.Nodes)
             {
                 allPoints.Add(new Vector2(n.X, n.Y));
-            });
+            }
 
             return new netDxf.BoundingRectangle(allPoints);
         }

--- a/FEALiTE2D.Plotting/Dxf/Plotter.cs
+++ b/FEALiTE2D.Plotting/Dxf/Plotter.cs
@@ -206,20 +206,16 @@ namespace FEALiTE2D.Plotting.Dxf
         {
             double scale = PlottingOption.StructureScaleFactor;
 
-            // loop through elements first to plot them
-            for (int i = 0; i < this.Structure.Elements.Count; i++)
+            foreach (var fe in this.Structure.Elements)
             {
-                foreach (var fe in this.Structure.Elements)
+                netDxf.Entities.Line line = new netDxf.Entities.Line(
+                        new netDxf.Vector2((startPosition.X + fe.Nodes[0].X) * scale, (startPosition.Y + fe.Nodes[0].Y) * scale),
+                        new netDxf.Vector2((startPosition.X + fe.Nodes[1].X) * scale, (startPosition.Y + fe.Nodes[1].Y) * scale))
                 {
-                    netDxf.Entities.Line line = new netDxf.Entities.Line(
-                            new netDxf.Vector2((startPosition.X + fe.Nodes[0].X) * scale, (startPosition.Y + fe.Nodes[0].Y) * scale),
-                            new netDxf.Vector2((startPosition.X + fe.Nodes[1].X) * scale, (startPosition.Y + fe.Nodes[1].Y) * scale))
-                    {
-                        Layer = this.PlottingOption.LayerOfStructure
-                    };
+                    Layer = this.PlottingOption.LayerOfStructure
+                };
 
-                    dxfDocument.AddEntity(line);
-                }
+                dxfDocument.AddEntity(line);
             }
         }
 

--- a/FEALiTE2D.Tests/Structure/StructureTest.cs
+++ b/FEALiTE2D.Tests/Structure/StructureTest.cs
@@ -135,10 +135,10 @@ namespace FEALiTE2D.Tests.Structure
             Assert.AreEqual(nd2.Uy, -0.06732180013884803);
             Assert.AreEqual(nd2.Rz, -0.0025498997289483097);
 
-            var ql1 = structure.Results.GetElementLocalFixedEndForeces(e1, loadCase);
-            var ql2 = structure.Results.GetElementLocalFixedEndForeces(e2, loadCase);
-            var fg1 = structure.Results.GetElementGlobalFixedEndForeces(e1, loadCase);
-            var fg2 = structure.Results.GetElementGlobalFixedEndForeces(e2, loadCase);
+            var ql1 = structure.Results.GetElementLocalFixedEndForces(e1, loadCase);
+            var ql2 = structure.Results.GetElementLocalFixedEndForces(e2, loadCase);
+            var fg1 = structure.Results.GetElementGlobalFixedEndForces(e1, loadCase);
+            var fg2 = structure.Results.GetElementGlobalFixedEndForces(e2, loadCase);
 
             Assert.AreEqual(ql1[0], 104.89205617337821);
             Assert.AreEqual(ql1[1], 18.488818091721274);
@@ -216,10 +216,10 @@ namespace FEALiTE2D.Tests.Structure
             Assert.AreEqual(nd2.Uy, -1.059915467868475);
             Assert.AreEqual(nd2.Rz, 0.00074191638715062017);
 
-            var ql1 = structure.Results.GetElementLocalFixedEndForeces(e1, loadCase);
-            var ql2 = structure.Results.GetElementLocalFixedEndForeces(e2, loadCase);
-            var fg1 = structure.Results.GetElementGlobalFixedEndForeces(e1, loadCase);
-            var fg2 = structure.Results.GetElementGlobalFixedEndForeces(e2, loadCase);
+            var ql1 = structure.Results.GetElementLocalFixedEndForces(e1, loadCase);
+            var ql2 = structure.Results.GetElementLocalFixedEndForces(e2, loadCase);
+            var fg1 = structure.Results.GetElementGlobalFixedEndForces(e1, loadCase);
+            var fg2 = structure.Results.GetElementGlobalFixedEndForces(e2, loadCase);
 
             Assert.AreEqual(ql1[0], 98.463276589933216);
             Assert.AreEqual(ql1[1], 20.91875793338594);

--- a/FEALiTE2D.Tests/Structure/StructureTest.cs
+++ b/FEALiTE2D.Tests/Structure/StructureTest.cs
@@ -901,5 +901,63 @@ namespace FEALiTE2D.Tests.Structure
             Assert.AreEqual(displElt1.Uy, totDispl, 1e-10);
             Assert.AreEqual(displElt2to5.Uy, totDispl, 1e-10);
         }
+
+        [Test]
+        public void TestFixedFixedBeam()
+        {
+            // Beam fixed at both ends (hyperstatic), uniform load
+            // Analytical: midspan deflection = -wL^4/(384EI), end moments = wL^2/12
+            // units: kN, m
+            FEALiTE2D.Structure.Structure structure = new FEALiTE2D.Structure.Structure();
+
+            Node2D n1 = new Node2D(0, 0, "n1");
+            Node2D n2 = new Node2D(6, 0, "n2");
+
+            n1.Support = new NodalSupport(true, true, true); // fixed
+            n2.Support = new NodalSupport(true, true, true); // fixed
+
+            structure.AddNode(n1, n2);
+
+            IMaterial material = new GenericIsotropicMaterial() { E = 210000000, U = 0.3, MaterialType = MaterialType.Steel };
+            Frame2DSection section = new RectangularSection(0.3, 0.5, material);
+
+            FrameElement2D e1 = new FrameElement2D(n1, n2, "e1") { CrossSection = section };
+            structure.AddElement(new[] { e1 });
+
+            LoadCase loadCase = new LoadCase("live", LoadCaseType.Live);
+            structure.LoadCasesToRun.Add(loadCase);
+            e1.Loads.Add(new FrameUniformLoad(0, -10, LoadDirection.Global, loadCase));
+
+            structure.LinearMesher.NumberSegments = 20;
+            structure.Solve();
+
+            double L = e1.Length;
+            double EI = material.E * section.Iz;
+            double w = 10;
+
+            double expectedMidspanDeflection = -w * Math.Pow(L, 4) / (384 * EI);
+            double expectedEndMoment = w * L * L / 12;
+
+            var d1 = structure.Results.GetNodeGlobalDisplacement(n1, loadCase);
+            var d2 = structure.Results.GetNodeGlobalDisplacement(n2, loadCase);
+
+            Assert.AreEqual(0, d1.Ux, 1e-10);
+            Assert.AreEqual(0, d1.Uy, 1e-10);
+            Assert.AreEqual(0, d1.Rz, 1e-10);
+            Assert.AreEqual(0, d2.Ux, 1e-10);
+            Assert.AreEqual(0, d2.Uy, 1e-10);
+            Assert.AreEqual(0, d2.Rz, 1e-10);
+
+            var midspanDisp = structure.Results.GetElementDisplacementAt(e1, loadCase, e1.Length / 2);
+            Assert.AreEqual(expectedMidspanDeflection, midspanDisp.Uy, 1e-6);
+
+            var reaction1 = structure.Results.GetSupportReaction(n1, loadCase);
+            var reaction2 = structure.Results.GetSupportReaction(n2, loadCase);
+
+            Assert.AreEqual(w * L / 2, reaction1.Fy, 1e-6);
+            Assert.AreEqual(w * L / 2, reaction2.Fy, 1e-6);
+            Assert.AreEqual(expectedEndMoment, reaction1.Mz, 1e-6);
+            Assert.AreEqual(-expectedEndMoment, reaction2.Mz, 1e-6);
+        }
     }
 }

--- a/FEALiTE2D.Tests/Structure/StructureTest.cs
+++ b/FEALiTE2D.Tests/Structure/StructureTest.cs
@@ -169,8 +169,8 @@ namespace FEALiTE2D.Tests.Structure
             Assert.AreEqual(fg2[5], -854.0740487820697);
 
             var op = new FEALiTE2D.Plotting.Dxf.PlottingOption { NFDScaleFactor = 0.5, SFDScaleFactor = 5.0, BMDScaleFactor = 0.1, DisplacmentScaleFactor = 100, DiagramsHorizontalOffsets = 200 };
-            var plotter = new FEALiTE2D. Plotting.Dxf.Plotter(structure, op);
-            plotter.Plot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)+"\\test.dxf", loadCase);
+            var plotter = new FEALiTE2D.Plotting.Dxf.Plotter(structure, op);
+            plotter.Plot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\test.dxf", loadCase);
         }
 
         [Test]
@@ -806,6 +806,117 @@ namespace FEALiTE2D.Tests.Structure
             FEALiTE2D.Plotting.Dxf.Plotter plotter = new Plotting.Dxf.Plotter(structure, op);
             plotter.Plot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\fixedEndBeam.dxf", loadCase);
 
+        }
+
+        [Test]
+        public void TestStructure_wShear()
+        {
+            // units are kN, m
+            FEALiTE2D.Structure.Structure structure = new FEALiTE2D.Structure.Structure();
+
+            FEALiTE2D.Structure.Structure.StructureOption options = new FEALiTE2D.Structure.Structure.StructureOption()
+            {
+                ShearStrainOption = FEALiTE2D.Structure.Structure.ShearStrainOption.TwoNodesTBTheory
+            };
+
+            var defaultoptions = FEALiTE2D.Structure.Structure.DefaultOptions;
+            
+
+            Node2D n1 = new Node2D(0, 0, "n1");
+            Node2D n2 = new Node2D(1, 0, "n2");
+            Node2D n3 = new Node2D(2, 0, "n3");
+            Node2D n4 = new Node2D(3, 0, "n4");
+            Node2D n5 = new Node2D(4, 0, "n5");
+            n1.Support = new NodalSupport(true, true, false); //pinned
+            n5.Support = new NodalSupport(false, true, false); //roller 
+
+            Node2D n1_ = new Node2D(0, 0, "n1_");
+            Node2D n2_ = new Node2D(1, 0, "n2_");
+            Node2D n3_ = new Node2D(2, 0, "n3_");
+            Node2D n4_ = new Node2D(3, 0, "n4_");
+            Node2D n5_ = new Node2D(4, 0, "n5_");
+            n1_.Support = new NodalSupport(true, true, false); //pinned
+            n5_.Support = new NodalSupport(false, true, false); //roller 
+
+            structure.AddNode(n1, n2, n3, n4, n5);
+            structure.AddNode(n1_, n2_, n3_, n4_, n5_);
+
+            IMaterial material = new GenericIsotropicMaterial() { E = 30E6, U = 0.2, Label = "Steel", Alpha = 0.000012, Gama = 39885, MaterialType = MaterialType.Steel };
+            Frame2DSection section = new Generic2DSection(0.075, 0.075 * 5 / 6, 0.075 * 5 / 6, 0.000480, 0.000480, 0.000480 * 2, 0.1, 0.1, material);
+
+            FrameElement2D e1 = new FrameElement2D(n1, n5, "e1") { CrossSection = section };
+            FrameElement2D e1_ = new FrameElement2D(n1_, n5_, "e1_") { CrossSection = section };
+
+            structure.AddElement(new[] { e1 }, options);
+            structure.AddElement(new[] { e1_ }, defaultoptions);
+
+            FrameElement2D e2 = new FrameElement2D(n1, n2, "e1") { CrossSection = section };
+            FrameElement2D e3 = new FrameElement2D(n2, n3, "e2") { CrossSection = section };
+            FrameElement2D e4 = new FrameElement2D(n3, n4, "e3") { CrossSection = section };
+            FrameElement2D e5 = new FrameElement2D(n4, n5, "e4") { CrossSection = section };
+
+            FrameElement2D e2_ = new FrameElement2D(n1_, n2_, "e1_") { CrossSection = section };
+            FrameElement2D e3_ = new FrameElement2D(n2_, n3_, "e2_") { CrossSection = section };
+            FrameElement2D e4_ = new FrameElement2D(n3_, n4_, "e3_") { CrossSection = section };
+            FrameElement2D e5_ = new FrameElement2D(n4_, n5_, "e4_") { CrossSection = section };
+
+            structure.AddNode(n1, n2, n3, n4, n5);
+            structure.AddNode(n1_, n2_, n3_, n4_, n5_);
+
+            structure.AddElement(new[] { e2, e3, e4, e5 }, options); // same elements as e1 but divided
+            structure.AddElement(new[] { e2_, e3_, e4_, e5_ }, defaultoptions); // same
+
+            LoadCase loadCase = new LoadCase("live", LoadCaseType.Live);
+            structure.LoadCasesToRun.Add(loadCase);
+            double wy = 12;
+            var fLoad = new FrameUniformLoad(0, -wy, LoadDirection.Global, loadCase);
+
+            foreach (var e in new[] { e1, e1_, e2, e2_, e3, e3_, e4, e4_, e5, e5_ })
+            {
+                e.Loads.Add(fLoad);
+            }
+
+            structure.LinearMesher.NumberSegments = 35;
+            structure.Solve();
+
+            var displElt1 = structure.Results.GetElementDisplacementAt(e1, loadCase, 2); //midspan
+            var displElt1_ = structure.Results.GetElementDisplacementAt(e1_, loadCase, 2);
+
+            var displElt2to5 = structure.Results.GetElementDisplacementAt(e3, loadCase, 1); // midspan
+            var displElt2to5_ = structure.Results.GetElementDisplacementAt(e3_, loadCase, 1);
+
+            double length = e1.Length;
+            double bendDispl = -wy * 5.0 / (384 * material.E * section.Iz) * Math.Pow(length, 4);
+
+            Assert.AreEqual(bendDispl, displElt1_.Uy, 1e-10);
+            Assert.AreEqual(bendDispl, displElt2to5_.Uy, 1e-10);
+
+            Assert.AreEqual(displElt1.Uy, displElt2to5.Uy, 1e-10); // midspan displacement should be same
+            Assert.AreEqual(displElt1_.Uy, displElt2to5_.Uy, 1e-10); // midspan displacement should be different due to shear
+
+            Assert.Greater(Math.Abs(displElt1.Uy), Math.Abs(displElt1.Uy)); // displacement with shear should be larger
+            Assert.Greater(Math.Abs(displElt2to5.Uy), Math.Abs(displElt2to5_.Uy)); // displacement with shear should be larger
+
+            /*
+            var d = structure.Results.GetNodeGlobalDisplacement(n2, loadCase);
+            var r = structure.Results.GetSupportReaction(n1, loadCase);
+            var verif = wy * 4 / 2;
+
+            double moment = wy * length / 8;
+            double shearDispl = -moment / (section.Az * material.G);
+            double totDispl = bendDispl +  shearDispl; // usual explicit formula for total displacement
+            Assert.AreEqual(nd1.Uy, totDispl, 1e-10);
+            */
+
+
+            /* 
+            double length = e1 .Length + e2.Length + e3.Length + e4.Length;
+            double bendDispl = - wy * 5.0 / (384 * material.E * section.Iz) * Math.Pow(length, 4);
+            double moment = wy * length / 8;
+            double shearDispl = -moment / (section.Az * material.G);
+            double totDispl = bendDispl + shearDispl; // usual explicit formula for total displacement
+            Assert.AreEqual(nd1.Uy, totDispl, 1e-10);
+            */
         }
     }
 }

--- a/FEALiTE2D.Tests/Structure/StructureTest.cs
+++ b/FEALiTE2D.Tests/Structure/StructureTest.cs
@@ -841,7 +841,7 @@ namespace FEALiTE2D.Tests.Structure
             structure.AddNode(n1, n2, n3, n4, n5);
             structure.AddNode(n1_, n2_, n3_, n4_, n5_);
 
-            IMaterial material = new GenericIsotropicMaterial() { E = 30E6, U = 0.2, Label = "Steel", Alpha = 0.000012, Gama = 39885, MaterialType = MaterialType.Steel };
+            IMaterial material = new GenericIsotropicMaterial() { E = 30E6, U = 2, Label = "Steel", Alpha = 0.000012, Gama = 39885, MaterialType = MaterialType.Steel };//U is deliberately high to make shear deformation more visible
             Frame2DSection section = new Generic2DSection(0.075, 0.075 * 5 / 6, 0.075 * 5 / 6, 0.000480, 0.000480, 0.000480 * 2, 0.1, 0.1, material);
 
             FrameElement2D e1 = new FrameElement2D(n1, n5, "e1") { CrossSection = section };

--- a/FEALiTE2D.Tests/Structure/StructureTest.cs
+++ b/FEALiTE2D.Tests/Structure/StructureTest.cs
@@ -816,7 +816,7 @@ namespace FEALiTE2D.Tests.Structure
 
             FEALiTE2D.Structure.Structure.StructureOption options = new FEALiTE2D.Structure.Structure.StructureOption()
             {
-                ShearStrainOption = FEALiTE2D.Structure.Structure.ShearStrainOption.TwoNodesTBTheory
+                BeamTheory = FEALiTE2D.Structure.Structure.BeamTheory.Timoshenko
             };
 
             var defaultoptions = FEALiTE2D.Structure.Structure.DefaultOptions;
@@ -850,15 +850,15 @@ namespace FEALiTE2D.Tests.Structure
             structure.AddElement(new[] { e1 }, options);
             structure.AddElement(new[] { e1_ }, defaultoptions);
 
-            FrameElement2D e2 = new FrameElement2D(n1, n2, "e1") { CrossSection = section };
-            FrameElement2D e3 = new FrameElement2D(n2, n3, "e2") { CrossSection = section };
-            FrameElement2D e4 = new FrameElement2D(n3, n4, "e3") { CrossSection = section };
-            FrameElement2D e5 = new FrameElement2D(n4, n5, "e4") { CrossSection = section };
+            FrameElement2D e2 = new FrameElement2D(n1, n2, "e2") { CrossSection = section };
+            FrameElement2D e3 = new FrameElement2D(n2, n3, "e3") { CrossSection = section };
+            FrameElement2D e4 = new FrameElement2D(n3, n4, "e4") { CrossSection = section };
+            FrameElement2D e5 = new FrameElement2D(n4, n5, "e5") { CrossSection = section };
 
-            FrameElement2D e2_ = new FrameElement2D(n1_, n2_, "e1_") { CrossSection = section };
-            FrameElement2D e3_ = new FrameElement2D(n2_, n3_, "e2_") { CrossSection = section };
-            FrameElement2D e4_ = new FrameElement2D(n3_, n4_, "e3_") { CrossSection = section };
-            FrameElement2D e5_ = new FrameElement2D(n4_, n5_, "e4_") { CrossSection = section };
+            FrameElement2D e2_ = new FrameElement2D(n1_, n2_, "e2_") { CrossSection = section };
+            FrameElement2D e3_ = new FrameElement2D(n2_, n3_, "e3_") { CrossSection = section };
+            FrameElement2D e4_ = new FrameElement2D(n3_, n4_, "e4_") { CrossSection = section };
+            FrameElement2D e5_ = new FrameElement2D(n4_, n5_, "e5_") { CrossSection = section };
 
             structure.AddNode(n1, n2, n3, n4, n5);
             structure.AddNode(n1_, n2_, n3_, n4_, n5_);
@@ -885,38 +885,21 @@ namespace FEALiTE2D.Tests.Structure
             var displElt2to5 = structure.Results.GetElementDisplacementAt(e3, loadCase, 1); // midspan
             var displElt2to5_ = structure.Results.GetElementDisplacementAt(e3_, loadCase, 1);
 
+            Assert.AreEqual(displElt1.Uy, displElt2to5.Uy, 1e-10); // midspan displacement: single element vs fine mesh with shear
+            Assert.AreEqual(displElt1_.Uy, displElt2to5_.Uy, 1e-10); // midspan displacement ssingle element vs fine mesh (both EB)
+
+            Assert.Greater(Math.Abs(displElt1.Uy), Math.Abs(displElt1_.Uy)); // displacement with shear should be larger
+            Assert.Greater(Math.Abs(displElt2to5.Uy), Math.Abs(displElt2to5_.Uy)); // displacement with shear should be larger
+
             double length = e1.Length;
             double bendDispl = -wy * 5.0 / (384 * material.E * section.Iz) * Math.Pow(length, 4);
-
             Assert.AreEqual(bendDispl, displElt1_.Uy, 1e-10);
             Assert.AreEqual(bendDispl, displElt2to5_.Uy, 1e-10);
 
-            Assert.AreEqual(displElt1.Uy, displElt2to5.Uy, 1e-10); // midspan displacement should be same
-            Assert.AreEqual(displElt1_.Uy, displElt2to5_.Uy, 1e-10); // midspan displacement should be different due to shear
-
-            Assert.Greater(Math.Abs(displElt1.Uy), Math.Abs(displElt1.Uy)); // displacement with shear should be larger
-            Assert.Greater(Math.Abs(displElt2to5.Uy), Math.Abs(displElt2to5_.Uy)); // displacement with shear should be larger
-
-            /*
-            var d = structure.Results.GetNodeGlobalDisplacement(n2, loadCase);
-            var r = structure.Results.GetSupportReaction(n1, loadCase);
-            var verif = wy * 4 / 2;
-
-            double moment = wy * length / 8;
-            double shearDispl = -moment / (section.Az * material.G);
-            double totDispl = bendDispl +  shearDispl; // usual explicit formula for total displacement
-            Assert.AreEqual(nd1.Uy, totDispl, 1e-10);
-            */
-
-
-            /* 
-            double length = e1 .Length + e2.Length + e3.Length + e4.Length;
-            double bendDispl = - wy * 5.0 / (384 * material.E * section.Iz) * Math.Pow(length, 4);
-            double moment = wy * length / 8;
-            double shearDispl = -moment / (section.Az * material.G);
-            double totDispl = bendDispl + shearDispl; // usual explicit formula for total displacement
-            Assert.AreEqual(nd1.Uy, totDispl, 1e-10);
-            */
+            double shearDispl = -wy * length * length / (8 * section.Az * material.G); // -wL²/(8GAz) = -M_max/(GAz)
+            double totDispl = bendDispl + shearDispl; // usual explicit formula for total displacement for simply supported beam with uniform load
+            Assert.AreEqual(displElt1.Uy, totDispl, 1e-10);
+            Assert.AreEqual(displElt2to5.Uy, totDispl, 1e-10);
         }
     }
 }

--- a/FEALiTE2D/CrossSections/CircularSection.cs
+++ b/FEALiTE2D/CrossSections/CircularSection.cs
@@ -39,7 +39,7 @@ namespace FEALiTE2D.CrossSections
             this.A = PI * d * d / 4.0;
             this.Ay = this.Az = this.A * 0.9;
             this.Iy = this.Iz = PI * d * d * d * d / 64.0;
-            this.J = 0.5 * this.Iy;
+            this.J = 2.0 * this.Iy;
             base.MaxWidth = base.MaxHeight = d;
         }
     }

--- a/FEALiTE2D/CrossSections/HollowTube.cs
+++ b/FEALiTE2D/CrossSections/HollowTube.cs
@@ -48,7 +48,7 @@ namespace FEALiTE2D.CrossSections
             double di = d - 2 * t;
             this.A = 0.25 * PI * (d * d - di * di);
             this.Ay = this.Az = this.A * 0.5;
-            this.Iy = this.Iy = PI * Pow(d / 2, 3) * t;
+            this.Iy = this.Iz = PI * Pow(d / 2, 3) * t;
             this.J = Iy + Iz;
             base.MaxWidth = base.MaxHeight = d;
         }       

--- a/FEALiTE2D/CrossSections/RectangularSection.cs
+++ b/FEALiTE2D/CrossSections/RectangularSection.cs
@@ -49,7 +49,7 @@ namespace FEALiTE2D.CrossSections
             this.Iy = b * b * b * t / 12.0;
             double _t = Max(b, t);
             double _b = Min(b, t);
-            double beta = 1.0 / 3.0 - 0.21 * (_b / _t) * (1 - Pow(_b / t, 4) / 12.0);
+            double beta = 1.0 / 3.0 - 0.21 * (_b / _t) * (1.0 - Pow(_b / _t, 4) / 12.0);
             this.J = beta * _b * _b * _b * _t;
             base.MaxWidth = b;
             base.MaxHeight = t;

--- a/FEALiTE2D/Elements/FrameElement2D.cs
+++ b/FEALiTE2D/Elements/FrameElement2D.cs
@@ -136,7 +136,7 @@ namespace FEALiTE2D.Elements
                    N5 = 3 * xsi2 - 2 * xsi3,
                    N6 = l * (-xsi2 + xsi3),
                    N7 = 6.0 * (-xsi + xsi2) / l,
-                   N8 = 1 - 4 * xsi - 3 * xsi2,
+                   N8 = 1 - 4 * xsi + 3 * xsi2,
                    N9 = 6.0 * (xsi - xsi2) / l,
                    N10 = -2 * xsi + 3.0 * xsi2;
             double[,] nu = new double[,]
@@ -532,6 +532,10 @@ namespace FEALiTE2D.Elements
             }
 
             double l = this.Length;
+            double l2 = l * l;
+            double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
+            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
+
             switch (this.EndRelease)
             {
                 default:
@@ -539,22 +543,46 @@ namespace FEALiTE2D.Elements
                     break;
                 case Frame2DEndRelease.StartRelease:
                     {
-                        f[1] -= 1.5 * f[2] / l;
-                        f[4] += 1.5 * f[2] / l;
-                        f[5] -= 0.5 * f[2];
+                        // Static condensation of θ₁: f[i] -= K[i,2] / K[2,2] · f[2]
+                        if (this.BeamTheory == BeamTheory.Timoshenko)
+                        {
+                            double Phi = 12 * this.CrossSection.Material.E * this.CrossSection.Iz / (l2 * this.CrossSection.GAz);
+                            f[1] -= 6 / (4 + Phi) * f[2] / l;          // v₁: K[1,2]/K[2,2]
+                            f[4] += 6 / (4 + Phi) * f[2] / l;          // v₂: -K[4,2]/K[2,2]
+                            f[5] -= (2 - Phi) / (4 + Phi) * f[2];      // θ₂: K[5,2]/K[2,2]
+                        }
+                        else
+                        {
+                            f[1] -= 1.5 * f[2] / l;   // v₁: K[1,2]/K[2,2] = 3/(2L)
+                            f[4] += 1.5 * f[2] / l;   // v₂: -K[4,2]/K[2,2] = 3/(2L)
+                            f[5] -= 0.5 * f[2];         // θ₂: K[5,2]/K[2,2] = 1/2
+                        }
                         f[2] = 0;
                         break;
                     }
                 case Frame2DEndRelease.EndRelease:
                     {
-                        f[1] -= 1.5 * f[5] / l;
-                        f[2] -= 0.5 * f[5];
-                        f[4] += 1.5 * f[5] / l;
+                        // Static condensation of θ₂: f[i] -= K[i,5] / K[5,5] · f[5]
+                        if (this.BeamTheory == BeamTheory.Timoshenko)
+                        {
+                            double Phi = 12 * this.CrossSection.Material.E * this.CrossSection.Iz / (l2 * this.CrossSection.GAz);
+                            f[1] -= 6 / (4 + Phi) * f[5] / l;          // v₁: K[1,5]/K[5,5]
+                            f[4] += 6 / (4 + Phi) * f[5] / l;          // v₂: -K[4,5]/K[5,5]
+                            f[2] -= (2 - Phi) / (4 + Phi) * f[5];      // θ₁: K[2,5]/K[5,5]
+                        }
+                        else
+                        {
+                            f[1] -= 1.5 * f[5] / l;   // v₁: K[1,5]/K[5,5] = 3/(2L)
+                            f[4] += 1.5 * f[5] / l;   // v₂: -K[4,5]/K[5,5] = 3/(2L)
+                            f[2] -= 0.5 * f[5];         // θ₁: K[2,5]/K[5,5] = 1/2
+                        }
                         f[5] = 0;
                         break;
                     }
                 case Frame2DEndRelease.FullRelease:
                     {
+                        // Condense θ₁ and θ₂: f_red = f_a - K_ab · K_bb⁻¹ · f_b
+                        // Result is identical for EB and Timoshenko: Δf_v1 = -(M1+M2)/L, Δf_v2 = +(M1+M2)/L
                         f[1] -= (f[2] + f[5]) / l;
                         f[4] += (f[2] + f[5]) / l;
                         f[2] = 0;

--- a/FEALiTE2D/Elements/FrameElement2D.cs
+++ b/FEALiTE2D/Elements/FrameElement2D.cs
@@ -97,6 +97,11 @@ namespace FEALiTE2D.Elements
         public Frame2DEndRelease EndRelease { get; set; }
 
         /// <summary>
+        /// Gets the shear strain option used when this element was initialized.
+        /// </summary>
+        public BeamTheory BeamTheory { get; private set; } = BeamTheory.EulerBernoulli;
+
+        /// <summary>
         /// Loads on the <see cref="FrameElement2D"/>.
         /// </summary>
         public IList<ILoad> Loads { get; set; }
@@ -214,47 +219,21 @@ namespace FEALiTE2D.Elements
 
         /// <inheritdoc/>
         public DenseMatrix LocalStiffnessMatrix { get; private set; }
-        private DenseMatrix GetLocalStiffnessMatrix(ShearStrainOption shearStrainOption)
+        private DenseMatrix GetLocalStiffnessMatrix(BeamTheory beamTheory)
         {
+            bool includeShear = beamTheory == BeamTheory.Timoshenko;
+
             switch (this.EndRelease)
             {
                 default:
                 case Frame2DEndRelease.NoRelease:
-                    {
-                        if (shearStrainOption == ShearStrainOption.Without)
-                            return Kl1_1();
-                        else if (shearStrainOption == ShearStrainOption.TwoNodesTBTheory)
-                            return Kl1_1_2NodesTB();            
-                        else //FieldConsistenceTheroy
-                        return Kl1_1_modTB();
-                    }
+                    return includeShear ? Kl1_1_shear() : Kl1_1();
                 case Frame2DEndRelease.StartRelease:
-                    {
-                        if (shearStrainOption == ShearStrainOption.Without)
-                            return Kl0_1();
-                        else if (shearStrainOption == ShearStrainOption.TwoNodesTBTheory)
-                            return Kl0_1_2NodesTB();
-                        else //FieldConsistenceTheroy
-                        return Kl0_1_modTB();
-                    }
+                    return includeShear ? Kl0_1_shear() : Kl0_1();
                 case Frame2DEndRelease.EndRelease:
-                    {
-                        if (shearStrainOption == ShearStrainOption.Without)
-                            return Kl1_0();
-                        else if (shearStrainOption == ShearStrainOption.TwoNodesTBTheory)
-                            return Kl1_0_2NodesTB();
-                        else //FieldConsistenceTheroy
-                        return Kl1_0_modTB();
-                    }
+                    return includeShear ? Kl1_0_shear() : Kl1_0();
                 case Frame2DEndRelease.FullRelease:
-                    {
-                        if (shearStrainOption == ShearStrainOption.Without)
-                            return Kl0_0();
-                        else if (shearStrainOption == ShearStrainOption.TwoNodesTBTheory)
-                            return Kl0_0_2NodesTB();
-                        else //FieldConsistencyTheroy   
-                        return Kl0_0_modTB();
-                    }
+                    return includeShear ? Kl0_0_shear() : Kl0_0();
             }
         }
 
@@ -303,7 +282,7 @@ namespace FEALiTE2D.Elements
          /// <summary>
         /// calculate local stiffness matrix when the frame has no releases
         /// </summary>
-        private DenseMatrix Kl1_1_2NodesTB()
+        private DenseMatrix Kl1_1_shear()
         {
             double l = this.Length;
             double l2 = l * l;
@@ -337,23 +316,15 @@ namespace FEALiTE2D.Elements
             k[4, 2] = -6 * EIL2 / (1 + Phi);
             k[4, 5] = -6 * EIL2 / (1 + Phi);
 
-            k[2, 2] = (4 + Phi / 12) * EIL / (1 + Phi);
-            k[5, 5] = (4 + Phi / 12) * EIL / (1 + Phi);
+            k[2, 2] = (4 + Phi) * EIL / (1 + Phi);
+            k[5, 5] = (4 + Phi) * EIL / (1 + Phi);
 
-            k[2, 5] = (2 - Phi / 12) * EIL;
-            k[5, 2] = (2 - Phi / 12) * EIL;
+            k[2, 5] = (2 - Phi) * EIL / (1 + Phi);
+            k[5, 2] = (2 - Phi) * EIL / (1 + Phi);
             return k;
         }
         
-         /// <summary>
-        /// calculate local stiffness matrix when the frame has no releases
-        /// </summary>
-        private DenseMatrix Kl1_1_modTB()
-        {
-            throw new System.NotImplementedException();
-            // to develop
-
-        }
+      
 
 
         /// <summary>
@@ -393,7 +364,7 @@ namespace FEALiTE2D.Elements
         /// <summary>
         /// calculate local stiffness matrix when there is a release at it's start
         /// </summary>
-        private DenseMatrix Kl0_1_2NodesTB()
+        private DenseMatrix Kl0_1_shear()
         {
             double l = this.Length;
             double l2 = l * l;
@@ -402,7 +373,9 @@ namespace FEALiTE2D.Elements
             double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
             double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
             double EIL3 = this.CrossSection.Material.E * this.CrossSection.Iz / l3;
-            double Phi = 12 / l2 * (this.CrossSection.EIz) / (this.CrossSection.GAz);
+            double Phi = 12 * (this.CrossSection.Material.E * this.CrossSection.Iz)
+            / (l2 * this.CrossSection.GAz);
+            double C = 4 + Phi;
 
             DenseMatrix k = new DenseMatrix(6, 6);
             
@@ -411,30 +384,21 @@ namespace FEALiTE2D.Elements
             k[0, 3] = -EAL;
             k[3, 0] = -EAL;
 
-            k[1, 1] = 3 * EIL3/ (1 + Phi);
-            k[4, 4] = 3 * EIL3/ (1 + Phi);
-            k[1, 4] = -3 * EIL3/ (1 + Phi);
-            k[4, 1] = -3 * EIL3/ (1 + Phi);
+            k[1, 1] = 12 * EIL3 / C;
+            k[4, 4] = 12 * EIL3 / C;
+            k[1, 4] = -12 * EIL3 / C;
+            k[4, 1] = -12 * EIL3 / C;
 
-            k[5, 1] = 3 * EIL2/ (1 + Phi);
-            k[1, 5] = 3 * EIL2/ (1 + Phi);
-            k[5, 4] = -3 * EIL2/ (1 + Phi);
-            k[4, 5] = -3 * EIL2/ (1 + Phi);
+            k[5, 1] = 12 * EIL2 / C;
+            k[1, 5] = 12 * EIL2 / C;
+            k[5, 4] = -12 * EIL2 / C;
+            k[4, 5] = -12 * EIL2 / C;
 
-            k[5, 5] = (3 + Phi) * EIL / (1 + Phi);
+            k[5, 5] = 12 * EIL / C;
             return k;
         }
-   /// <summary>
-        /// calculate local stiffness matrix when the frame has no releases
-        /// </summary>
-        private DenseMatrix Kl0_1_modTB()
-        {
-            throw new System.NotImplementedException();
-            // to develop
-
-        }
-        ///<summary>
-        /// calculate local stiffness matrix when there is a release at it's end
+        /// <summary>
+        /// calculate local stiffness matrix when there is a release at its end
         /// </summary>
         private DenseMatrix Kl1_0()
         {
@@ -468,9 +432,9 @@ namespace FEALiTE2D.Elements
         }
 
         /// <summary>
-        /// calculate local stiffness matrix when there is a release at it's end
+        /// calculate local stiffness matrix when there is a release at its end (Timoshenko)
         /// </summary>
-        private DenseMatrix Kl1_0_2NodesTB()
+        private DenseMatrix Kl1_0_shear()
         {
             double l = this.Length;
             double l2 = l * l;
@@ -479,7 +443,9 @@ namespace FEALiTE2D.Elements
             double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
             double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
             double EIL3 = this.CrossSection.Material.E * this.CrossSection.Iz / l3;
-            double Phi = 12 / l2 * (this.CrossSection.EIz) / (this.CrossSection.GAz);
+            double Phi = 12 * (this.CrossSection.Material.E * this.CrossSection.Iz)
+            / (l2 * this.CrossSection.GAz);
+            double C = 4 + Phi;
 
             DenseMatrix k = new DenseMatrix(6, 6);
 
@@ -488,29 +454,21 @@ namespace FEALiTE2D.Elements
             k[0, 3] = -EAL;
             k[3, 0] = -EAL;
 
-            k[1, 1] = 3 * EIL3 / (1 + Phi);
-            k[4, 4] = 3 * EIL3 / (1 + Phi);
-            k[1, 4] = -3 * EIL3 / (1 + Phi);
-            k[4, 1] = -3 * EIL3 / (1 + Phi);
+            k[1, 1] = 12 * EIL3 / C;
+            k[4, 4] = 12 * EIL3 / C;
+            k[1, 4] = -12 * EIL3 / C;
+            k[4, 1] = -12 * EIL3 / C;
 
-            k[2, 1] = 3 * EIL2 / (1 + Phi);
-            k[1, 2] = 3 * EIL2 / (1 + Phi);
-            k[2, 4] = -3 * EIL2 / (1 + Phi);
-            k[4, 2] = -3 * EIL2 / (1 + Phi);
+            k[2, 1] = 12 * EIL2 / C;
+            k[1, 2] = 12 * EIL2 / C;
+            k[2, 4] = -12 * EIL2 / C;
+            k[4, 2] = -12 * EIL2 / C;
 
-            k[2, 2] = (3 + Phi) * EIL / (1 + Phi);
+            k[2, 2] = 12 * EIL / C;
             return k;
         }
         
-        /// <summary>
-        /// calculate local stiffness matrix when the frame has no releases
-        /// </summary>
-        private DenseMatrix Kl1_0_modTB()
-        {
-            throw new System.NotImplementedException();
-            // to develop
 
-        }
         /// <summary>
         /// calculate local stiffness matrix when it's fully released.
         /// </summary>
@@ -528,7 +486,7 @@ namespace FEALiTE2D.Elements
             return k;
         }
 
-        private DenseMatrix Kl0_0_2NodesTB()
+        private DenseMatrix Kl0_0_shear()
         {
             double l = this.Length;
             double EAL = this.CrossSection.Material.E * this.CrossSection.A / l;
@@ -542,15 +500,7 @@ namespace FEALiTE2D.Elements
             return k;
         }
 
-        /// <summary>
-        /// calculate local stiffness matrix when the frame has no releases
-        /// </summary>
-        private DenseMatrix Kl0_0_modTB()
-        {
-            throw new System.NotImplementedException();
-            // to develop
 
-        }
 
 
         /// <inheritdoc/>
@@ -616,8 +566,16 @@ namespace FEALiTE2D.Elements
         }
 
         /// <inheritdoc/>
-        public void Initialize(Structure.Structure.ShearStrainOption options)
+        public void Initialize(Structure.Structure.BeamTheory options)
         {
+            if (options == BeamTheory.Timoshenko)
+            {
+                if (this.CrossSection.Material.G == 0)
+                    throw new System.ArgumentException($"Timoshenko beam theory requires a non-zero shear modulus G. Element '{this.Label}' has G = 0.");
+                if (this.CrossSection.Az == 0)
+                    throw new System.ArgumentException($"Timoshenko beam theory requires a non-zero shear area Az. Element '{this.Label}' has Az = 0.");
+            }
+            this.BeamTheory = options;
             this.LocalCoordinateSystemMatrix = GetLocalCoordinateSystemMatrix();
             this.TransformationMatrix = GetTransformationMatrix();
             this.LocalStiffnessMatrix = GetLocalStiffnessMatrix(options);
@@ -627,7 +585,7 @@ namespace FEALiTE2D.Elements
         /// <inheritdoc/>
         public void Initialize()
         {
-            Initialize(Structure.Structure.DefaultOptions.ShearStrainOption);
+            Initialize(Structure.Structure.DefaultOptions.BeamTheory);
         }
     }
 

--- a/FEALiTE2D/Elements/FrameElement2D.cs
+++ b/FEALiTE2D/Elements/FrameElement2D.cs
@@ -533,8 +533,6 @@ namespace FEALiTE2D.Elements
 
             double l = this.Length;
             double l2 = l * l;
-            double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
-            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
 
             switch (this.EndRelease)
             {

--- a/FEALiTE2D/Elements/FrameElement2D.cs
+++ b/FEALiTE2D/Elements/FrameElement2D.cs
@@ -4,6 +4,7 @@ using FEALiTE2D.Loads;
 using System.Linq;
 using System.Collections.Generic;
 using static System.Math;
+using static FEALiTE2D.Structure.Structure;
 
 namespace FEALiTE2D.Elements
 {
@@ -213,26 +214,46 @@ namespace FEALiTE2D.Elements
 
         /// <inheritdoc/>
         public DenseMatrix LocalStiffnessMatrix { get; private set; }
-        private DenseMatrix GetLocalStiffnessMatrix()
+        private DenseMatrix GetLocalStiffnessMatrix(ShearStrainOption shearStrainOption)
         {
             switch (this.EndRelease)
             {
                 default:
                 case Frame2DEndRelease.NoRelease:
                     {
-                        return Kl1_1();
+                        if (shearStrainOption == ShearStrainOption.Without)
+                            return Kl1_1();
+                        else if (shearStrainOption == ShearStrainOption.TwoNodesTBTheory)
+                            return Kl1_1_2NodesTB();            
+                        else //FieldConsistenceTheroy
+                        return Kl1_1_modTB();
                     }
                 case Frame2DEndRelease.StartRelease:
                     {
-                        return Kl0_1();
+                        if (shearStrainOption == ShearStrainOption.Without)
+                            return Kl0_1();
+                        else if (shearStrainOption == ShearStrainOption.TwoNodesTBTheory)
+                            return Kl0_1_2NodesTB();
+                        else //FieldConsistenceTheroy
+                        return Kl0_1_modTB();
                     }
                 case Frame2DEndRelease.EndRelease:
                     {
-                        return Kl1_0();
+                        if (shearStrainOption == ShearStrainOption.Without)
+                            return Kl1_0();
+                        else if (shearStrainOption == ShearStrainOption.TwoNodesTBTheory)
+                            return Kl1_0_2NodesTB();
+                        else //FieldConsistenceTheroy
+                        return Kl1_0_modTB();
                     }
                 case Frame2DEndRelease.FullRelease:
                     {
-                        return Kl0_0();
+                        if (shearStrainOption == ShearStrainOption.Without)
+                            return Kl0_0();
+                        else if (shearStrainOption == ShearStrainOption.TwoNodesTBTheory)
+                            return Kl0_0_2NodesTB();
+                        else //FieldConsistencyTheroy   
+                        return Kl0_0_modTB();
                     }
             }
         }
@@ -279,6 +300,62 @@ namespace FEALiTE2D.Elements
             return k;
         }
 
+         /// <summary>
+        /// calculate local stiffness matrix when the frame has no releases
+        /// </summary>
+        private DenseMatrix Kl1_1_2NodesTB()
+        {
+            double l = this.Length;
+            double l2 = l * l;
+            double l3 = l * l * l;
+            double EAL = this.CrossSection.Material.E * this.CrossSection.A / l;
+            double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
+            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
+            double EIL3 = this.CrossSection.Material.E * this.CrossSection.Iz / l3;
+            double Phi = 12 * (this.CrossSection.Material.E * this.CrossSection.Iz)
+            / (l2 * this.CrossSection.GAz);
+
+            DenseMatrix k = new DenseMatrix(6, 6);
+
+            k[0, 0] = EAL;
+            k[3, 3] = EAL;
+            k[0, 3] = -EAL;
+            k[3, 0] = -EAL;
+
+
+            k[1, 1] = 12 * EIL3 / (1 + Phi);
+            k[4, 4] = 12 * EIL3 / (1 + Phi);
+            k[1, 4] = -12 * EIL3 / (1 + Phi);
+            k[4, 1] = -12 * EIL3 / (1 + Phi);
+
+            k[2, 1] = 6 * EIL2 / (1 + Phi);
+            k[5, 1] = 6 * EIL2 / (1 + Phi);
+            k[1, 2] = 6 * EIL2 / (1 + Phi);
+            k[1, 5] = 6 * EIL2 / (1 + Phi);
+            k[2, 4] = -6 * EIL2 / (1 + Phi);
+            k[5, 4] = -6 * EIL2 / (1 + Phi);
+            k[4, 2] = -6 * EIL2 / (1 + Phi);
+            k[4, 5] = -6 * EIL2 / (1 + Phi);
+
+            k[2, 2] = (4 + Phi / 12) * EIL / (1 + Phi);
+            k[5, 5] = (4 + Phi / 12) * EIL / (1 + Phi);
+
+            k[2, 5] = (2 - Phi / 12) * EIL;
+            k[5, 2] = (2 - Phi / 12) * EIL;
+            return k;
+        }
+        
+         /// <summary>
+        /// calculate local stiffness matrix when the frame has no releases
+        /// </summary>
+        private DenseMatrix Kl1_1_modTB()
+        {
+            throw new System.NotImplementedException();
+            // to develop
+
+        }
+
+
         /// <summary>
         /// calculate local stiffness matrix when there is a release at it's start
         /// </summary>
@@ -314,6 +391,49 @@ namespace FEALiTE2D.Elements
         }
 
         /// <summary>
+        /// calculate local stiffness matrix when there is a release at it's start
+        /// </summary>
+        private DenseMatrix Kl0_1_2NodesTB()
+        {
+            double l = this.Length;
+            double l2 = l * l;
+            double l3 = l * l * l;
+            double EAL = this.CrossSection.Material.E * this.CrossSection.A / l;
+            double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
+            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
+            double EIL3 = this.CrossSection.Material.E * this.CrossSection.Iz / l3;
+            double Phi = 12 / l2 * (this.CrossSection.EIz) / (this.CrossSection.GAz);
+
+            DenseMatrix k = new DenseMatrix(6, 6);
+            
+            k[0, 0] = EAL;
+            k[3, 3] = EAL;
+            k[0, 3] = -EAL;
+            k[3, 0] = -EAL;
+
+            k[1, 1] = 3 * EIL3/ (1 + Phi);
+            k[4, 4] = 3 * EIL3/ (1 + Phi);
+            k[1, 4] = -3 * EIL3/ (1 + Phi);
+            k[4, 1] = -3 * EIL3/ (1 + Phi);
+
+            k[5, 1] = 3 * EIL2/ (1 + Phi);
+            k[1, 5] = 3 * EIL2/ (1 + Phi);
+            k[5, 4] = -3 * EIL2/ (1 + Phi);
+            k[4, 5] = -3 * EIL2/ (1 + Phi);
+
+            k[5, 5] = (3 + Phi) * EIL / (1 + Phi);
+            return k;
+        }
+   /// <summary>
+        /// calculate local stiffness matrix when the frame has no releases
+        /// </summary>
+        private DenseMatrix Kl0_1_modTB()
+        {
+            throw new System.NotImplementedException();
+            // to develop
+
+        }
+        ///<summary>
         /// calculate local stiffness matrix when there is a release at it's end
         /// </summary>
         private DenseMatrix Kl1_0()
@@ -348,6 +468,50 @@ namespace FEALiTE2D.Elements
         }
 
         /// <summary>
+        /// calculate local stiffness matrix when there is a release at it's end
+        /// </summary>
+        private DenseMatrix Kl1_0_2NodesTB()
+        {
+            double l = this.Length;
+            double l2 = l * l;
+            double l3 = l * l * l;
+            double EAL = this.CrossSection.Material.E * this.CrossSection.A / l;
+            double EIL = this.CrossSection.Material.E * this.CrossSection.Iz / l;
+            double EIL2 = this.CrossSection.Material.E * this.CrossSection.Iz / l2;
+            double EIL3 = this.CrossSection.Material.E * this.CrossSection.Iz / l3;
+            double Phi = 12 / l2 * (this.CrossSection.EIz) / (this.CrossSection.GAz);
+
+            DenseMatrix k = new DenseMatrix(6, 6);
+
+            k[0, 0] = EAL;
+            k[3, 3] = EAL;
+            k[0, 3] = -EAL;
+            k[3, 0] = -EAL;
+
+            k[1, 1] = 3 * EIL3 / (1 + Phi);
+            k[4, 4] = 3 * EIL3 / (1 + Phi);
+            k[1, 4] = -3 * EIL3 / (1 + Phi);
+            k[4, 1] = -3 * EIL3 / (1 + Phi);
+
+            k[2, 1] = 3 * EIL2 / (1 + Phi);
+            k[1, 2] = 3 * EIL2 / (1 + Phi);
+            k[2, 4] = -3 * EIL2 / (1 + Phi);
+            k[4, 2] = -3 * EIL2 / (1 + Phi);
+
+            k[2, 2] = (3 + Phi) * EIL / (1 + Phi);
+            return k;
+        }
+        
+        /// <summary>
+        /// calculate local stiffness matrix when the frame has no releases
+        /// </summary>
+        private DenseMatrix Kl1_0_modTB()
+        {
+            throw new System.NotImplementedException();
+            // to develop
+
+        }
+        /// <summary>
         /// calculate local stiffness matrix when it's fully released.
         /// </summary>
         private DenseMatrix Kl0_0()
@@ -363,6 +527,31 @@ namespace FEALiTE2D.Elements
             k[3, 0] = -EAL;
             return k;
         }
+
+        private DenseMatrix Kl0_0_2NodesTB()
+        {
+            double l = this.Length;
+            double EAL = this.CrossSection.Material.E * this.CrossSection.A / l;
+
+            DenseMatrix k = new DenseMatrix(6, 6);
+
+            k[0, 0] = EAL;
+            k[3, 3] = EAL;
+            k[0, 3] = -EAL;
+            k[3, 0] = -EAL;
+            return k;
+        }
+
+        /// <summary>
+        /// calculate local stiffness matrix when the frame has no releases
+        /// </summary>
+        private DenseMatrix Kl0_0_modTB()
+        {
+            throw new System.NotImplementedException();
+            // to develop
+
+        }
+
 
         /// <inheritdoc/>
         public DenseMatrix GlobalStiffnessMatrix { get; private set; }
@@ -427,14 +616,19 @@ namespace FEALiTE2D.Elements
         }
 
         /// <inheritdoc/>
-        public void Initialize()
+        public void Initialize(Structure.Structure.ShearStrainOption options)
         {
             this.LocalCoordinateSystemMatrix = GetLocalCoordinateSystemMatrix();
             this.TransformationMatrix = GetTransformationMatrix();
-            this.LocalStiffnessMatrix = GetLocalStiffnessMatrix();
+            this.LocalStiffnessMatrix = GetLocalStiffnessMatrix(options);
             this.GlobalStiffnessMatrix = GetGlobalStiffnessMatrix();
         }
 
+        /// <inheritdoc/>
+        public void Initialize()
+        {
+            Initialize(Structure.Structure.DefaultOptions.ShearStrainOption);
+        }
     }
 
 

--- a/FEALiTE2D/Elements/Node2D.cs
+++ b/FEALiTE2D/Elements/Node2D.cs
@@ -61,7 +61,7 @@ namespace FEALiTE2D.Elements
         /// <summary>
         /// An angle of rotation of the of local axes of the node around Z-axis.
         /// </summary>
-        public double RotaionAngle { get; set; }
+        public double RotationAngle { get; set; }
 
         /// <summary>
         /// Gets number of degrees of freedom of the node.
@@ -106,14 +106,14 @@ namespace FEALiTE2D.Elements
         public Structure.Structure ParentStructure { get; set; }
 
         /// <summary>
-        /// Transformation matrix of the Node due to a <see cref="RotaionAngle"/>.
+        /// Transformation matrix of the Node due to a <see cref="RotationAngle"/>.
         /// </summary>
         public CSparse.Double.DenseMatrix TransformationMatrix
         {
             get
             {
-                double c = Cos(RotaionAngle);
-                double s = Sin(RotaionAngle);
+                double c = Cos(RotationAngle);
+                double s = Sin(RotationAngle);
                 double[,] t = new double[,]
                 {
                     { c, s, 0 },

--- a/FEALiTE2D/Loads/LoadCase.cs
+++ b/FEALiTE2D/Loads/LoadCase.cs
@@ -76,21 +76,17 @@
         /// <inheritdoc/>
         public static bool operator ==(LoadCase lc1, LoadCase lc2)
         {
+            if (ReferenceEquals(lc1, lc2))
+                return true;
             if (lc1 is null)
-            {
                 return false;
-            }
             return lc1.Equals(lc2);
         }
 
         /// <inheritdoc/>
         public static bool operator !=(LoadCase lc1, LoadCase lc2)
         {
-            if (lc1 is null)
-            {
-                return false;
-            }
-            return !lc1.Equals(lc2);
+            return !(lc1 == lc2);
         }
 
         /// <inheritdoc/>

--- a/FEALiTE2D/Loads/NodalLoad.cs
+++ b/FEALiTE2D/Loads/NodalLoad.cs
@@ -93,21 +93,17 @@ namespace FEALiTE2D.Loads
         /// <inheritdoc/>
         public static bool operator ==(NodalLoad nl1, NodalLoad nl2)
         {
+            if (ReferenceEquals(nl1, nl2))
+                return true;
             if (nl1 is null)
-            {
                 return false;
-            }
             return nl1.Equals(nl2);
         }
 
         /// <inheritdoc/>
         public static bool operator !=(NodalLoad nl1, NodalLoad nl2)
         {
-            if (ReferenceEquals(nl1, null))
-            {
-                return false;
-            }
-            return !nl1.Equals(nl2);
+            return !(nl1 == nl2);
         }
 
         /// <inheritdoc/>

--- a/FEALiTE2D/Loads/SupportDisplacementLoad.cs
+++ b/FEALiTE2D/Loads/SupportDisplacementLoad.cs
@@ -91,21 +91,17 @@ namespace FEALiTE2D.Loads
         /// <inheritdoc/>
         public static bool operator ==(SupportDisplacementLoad nl1, SupportDisplacementLoad nl2)
         {
+            if (ReferenceEquals(nl1, nl2))
+                return true;
             if (ReferenceEquals(nl1, null))
-            {
                 return false;
-            }
             return nl1.Equals(nl2);
         }
 
         /// <inheritdoc/>
         public static bool operator !=(SupportDisplacementLoad nl1, SupportDisplacementLoad nl2)
         {
-            if (ReferenceEquals(nl1, null))
-            {
-                return false;
-            }
-            return !nl1.Equals(nl2);
+            return !(nl1 == nl2);
         }
 
         /// <inheritdoc/>

--- a/FEALiTE2D/Meshing/LinearMeshSegment.cs
+++ b/FEALiTE2D/Meshing/LinearMeshSegment.cs
@@ -25,6 +25,8 @@ namespace FEALiTE2D.Meshing
                             Displacement2;  // displacement at end of  the segment.
         public double  EIz, // modulus of elasticity times second moment of inertial of the cross-section at the segment.area 
                        EA; // modulus of elasticity times area of the cross-section at the segment.
+        public FEALiTE2D.Structure.Structure.BeamTheory BeamTheory = FEALiTE2D.Structure.Structure.BeamTheory.EulerBernoulli;
+        public double GAz; // shear modulus times shear area of the cross-section at the segment.
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 
@@ -105,7 +107,7 @@ namespace FEALiTE2D.Meshing
         /// <param name="x">a distance</param>
         public double VerticalDisplacementAt(double x)
         {
-            return Displacement1.Uy +
+            double v_bending = Displacement1.Uy +
                 (
                     Displacement1.Rz * x -
                     (
@@ -115,6 +117,18 @@ namespace FEALiTE2D.Meshing
                          - x * x * x * x * x * ((wy2 - wy1) / (x2 - x1)) / 120.0 // uniform and trap load.
                     ) / (EIz)
                 );
+
+            if (BeamTheory == FEALiTE2D.Structure.Structure.BeamTheory.EulerBernoulli)
+                return v_bending;
+
+            // Timoshenko shear correction: v_shear = -integral(V/GAz, dx)
+            double shearCorrection = -(
+                Internalforces1.Fy * x
+                + wy1 * x * x / 2.0
+                + (wy2 - wy1) * x * x * x / (6.0 * (x2 - x1))
+            ) / GAz;
+
+            return v_bending + shearCorrection;
         }
 
         /// <summary>

--- a/FEALiTE2D/Meshing/LinearMeshSegment.cs
+++ b/FEALiTE2D/Meshing/LinearMeshSegment.cs
@@ -87,7 +87,11 @@ namespace FEALiTE2D.Meshing
         }
 
         /// <summary>
-        /// Get slope angle of a point on a segment due to loads
+        /// Get the cross-section rotation at a point on a segment.
+        /// This is θ(x) = θ₀ - ∫(M/EI)dx, which is the same in both Euler-Bernoulli
+        /// and Timoshenko theory. It is NOT the slope dv/dx (which differs in Timoshenko
+        /// by the shear angle γ = V/GAz). The DOF Rz in the displacement vector is this
+        /// rotation, not the slope.
         /// </summary>
         /// <param name="x">a distance</param>
         public double SlopeAngleAt(double x)

--- a/FEALiTE2D/Meshing/LinearMesher.cs
+++ b/FEALiTE2D/Meshing/LinearMesher.cs
@@ -124,8 +124,13 @@ namespace FEALiTE2D.Meshing
                 // set geometric properties.
                 if (!(element is SpringElement2D))
                 {
-                       segment.EIz = element.CrossSection.EIz;
+                    segment.EIz = element.CrossSection.EIz;
                     segment.EA = element.CrossSection.EA;
+                    if (element is FrameElement2D fe)
+                    {
+                        segment.BeamTheory = fe.BeamTheory;
+                        segment.GAz = fe.CrossSection.GAz;
+                    }
                 }
 
                 element.MeshSegments.Add(segment);

--- a/FEALiTE2D/Structure/Assembler.cs
+++ b/FEALiTE2D/Structure/Assembler.cs
@@ -31,9 +31,9 @@ namespace FEALiTE2D.Structure
         {
             int nDOF = structure.nDOF;
 
-            // check if there are free dofs available.
+            // fully restrained structure: no free DOFs, skip assembly
             if (structure.nDOF == 0)
-                throw new InvalidOperationException("There are no sufficient degrees of freedom, thus there are no displacements or rotations could occur!");
+                return null;
 
             // global stiffness matrix.
             DenseMatrix Kg = new DenseMatrix(nDOF, nDOF);
@@ -106,9 +106,9 @@ namespace FEALiTE2D.Structure
         /// <param name="loadCase">load case</param>
         internal double[] AssembleGlobalEquivalentLoadVector(LoadCase loadCase)
         {
-            // check if there are free dofs available.
+            // fully restrained structure: no free DOFs, skip assembly
             if (structure.nDOF == 0)
-                throw new InvalidOperationException("There are no sufficient degrees of freedom, thus there are no displacements or rotations could occur!");
+                return new double[0];
 
             int nDOF = structure.nDOF;
 

--- a/FEALiTE2D/Structure/PostProcessor.cs
+++ b/FEALiTE2D/Structure/PostProcessor.cs
@@ -399,6 +399,8 @@ namespace FEALiTE2D.Structure
                 temp.x2 = cSegment.x2;
                 temp.EIz = cSegment.EIz;
                 temp.EA = cSegment.EA;
+                temp.GAz = cSegment.GAz;
+                temp.BeamTheory = cSegment.BeamTheory;
                 list.Add(temp);
             }
 

--- a/FEALiTE2D/Structure/PostProcessor.cs
+++ b/FEALiTE2D/Structure/PostProcessor.cs
@@ -75,7 +75,7 @@ namespace FEALiTE2D.Structure
             // reactions are the sum of global external fixed end forces
             foreach (var e in connectedElements)
             {
-                double[] fext = this.GetElementGlobalFixedEndForeces(e, loadCase);
+                double[] fext = this.GetElementGlobalFixedEndForces(e, loadCase);
 
                 if (e.Nodes[0] == node)
                 {
@@ -158,7 +158,7 @@ namespace FEALiTE2D.Structure
         /// <param name="element">an element</param>
         /// <param name="loadCase">a load case</param>
         /// <returns>Local End forces of an element after the structure is solved.</returns>
-        public double[] GetElementLocalFixedEndForeces(IElement element, LoadCase loadCase)
+        public double[] GetElementLocalFixedEndForces(IElement element, LoadCase loadCase)
         {
             double[] q = new double[6];
 
@@ -187,9 +187,9 @@ namespace FEALiTE2D.Structure
         /// <param name="element">an element</param>
         /// <param name="loadCase">a load case</param>
         /// <returns>Global End forces of an element after the structure is solved.</returns>
-        public double[] GetElementGlobalFixedEndForeces(IElement element, LoadCase loadCase)
+        public double[] GetElementGlobalFixedEndForces(IElement element, LoadCase loadCase)
         {
-            double[] ql = this.GetElementLocalFixedEndForeces(element, loadCase);
+            double[] ql = this.GetElementLocalFixedEndForces(element, loadCase);
 
             // fg = Tt*fl
             double[] fg = new double[ql.Length];
@@ -226,7 +226,7 @@ namespace FEALiTE2D.Structure
             double len = element.Length;
 
             // get local end forces after the structure is solved
-            double[] fl = this.GetElementLocalFixedEndForeces(element, loadCase);
+            double[] fl = this.GetElementLocalFixedEndForces(element, loadCase);
             double[] dl = this.GetElementLocalEndDisplacement(element, loadCase);
 
             //loop through each segment

--- a/FEALiTE2D/Structure/Structure.cs
+++ b/FEALiTE2D/Structure/Structure.cs
@@ -285,6 +285,10 @@ namespace FEALiTE2D.Structure
 
             Assembler assembler = new Assembler(this);
 
+            // Clear previous results to allow re-solving
+            this.FixedEndLoadsVectors.Clear();
+            this.DisplacementVectors.Clear();
+
             this.StructuralStiffnessMatrix = assembler.AssembleGlobalStiffnessMatrix();
 
             for (int i = 0; i < LoadCasesToRun.Count; i++)

--- a/FEALiTE2D/Structure/Structure.cs
+++ b/FEALiTE2D/Structure/Structure.cs
@@ -248,7 +248,14 @@ namespace FEALiTE2D.Structure
         /// <summary>
         /// Solve the structure.
         /// </summary>
-        public void Solve(bool detailedAnalysisOutput = true)
+        /// <param name="detailedAnalysisOutput">Whether to print analysis timing information to the console.</param>
+        /// <param name="allowQRFallback">
+        /// TEMPORARY: If true, falls back to QR factorization when Cholesky fails (matrix not SPD).
+        /// This indicates an unstable structure (mechanism) and QR will produce numerically unreliable results.
+        /// If false (default), Cholesky failure throws an exception with a clear error message.
+        /// This option will be removed once proper instability detection is implemented.
+        /// </param>
+        public void Solve(bool detailedAnalysisOutput = true, bool allowQRFallback = false)
         {
             if (!CopyrightDisplayed)
             {
@@ -287,28 +294,44 @@ namespace FEALiTE2D.Structure
                 this.FixedEndLoadsVectors.Add(currentLC, loadVec);
             }
 
-            CSparse.Factorization.ISparseFactorization<double> cholesky = null;
+            if (nDOF > 0)
+            {
+                CSparse.Factorization.ISparseFactorization<double> cholesky;
 
-            try
-            {
-                cholesky = CSparse.Double.Factorization.SparseCholesky.Create(StructuralStiffnessMatrix, ColumnOrdering.MinimumDegreeAtPlusA);
-            }
-            catch (Exception e)
-            {
-                if (e.Message.Contains("Matrix must be symmetric positive definite."))
+                if (allowQRFallback)
                 {
-                    cholesky = CSparse.Double.Factorization.SparseQR.Create(StructuralStiffnessMatrix, ColumnOrdering.Natural);
+                    // TEMPORARY: fallback to QR if Cholesky fails (matrix not SPD = mechanism).
+                    // This should be removed once instability detection is properly implemented.
+                    try
+                    {
+                        cholesky = CSparse.Double.Factorization.SparseCholesky.Create(StructuralStiffnessMatrix, ColumnOrdering.MinimumDegreeAtPlusA);
+                    }
+                    catch (Exception)
+                    {
+                        cholesky = CSparse.Double.Factorization.SparseQR.Create(StructuralStiffnessMatrix, ColumnOrdering.Natural);
+                    }
+                }
+                else
+                {
+                    cholesky = CSparse.Double.Factorization.SparseCholesky.Create(StructuralStiffnessMatrix, ColumnOrdering.MinimumDegreeAtPlusA);
+                }
+
+                for (int i = 0; i < LoadCasesToRun.Count; i++)
+                {
+                    LoadCase currentLC = this.LoadCasesToRun[i];
+                    double[] displacementVector = new double[nDOF];
+
+                    cholesky.Solve(FixedEndLoadsVectors[currentLC], displacementVector);
+
+                    this.DisplacementVectors.Add(currentLC, displacementVector);
                 }
             }
-
-            for (int i = 0; i < LoadCasesToRun.Count; i++)
+            else
             {
-                LoadCase currentLC = this.LoadCasesToRun[i];
-                double[] displacementVector = new double[nDOF];
-
-                cholesky.Solve(FixedEndLoadsVectors[currentLC], displacementVector);
-
-                this.DisplacementVectors.Add(currentLC, displacementVector);
+                for (int i = 0; i < LoadCasesToRun.Count; i++)
+                {
+                    this.DisplacementVectors.Add(LoadCasesToRun[i], new double[0]);
+                }
             }
 
             AnalysisStatus = AnalysisStatus.Successful;

--- a/FEALiTE2D/Structure/Structure.cs
+++ b/FEALiTE2D/Structure/Structure.cs
@@ -143,7 +143,7 @@ namespace FEALiTE2D.Structure
                 this.Elements.Add(element);
                 if (element is FrameElement2D frameElem)
                 {
-                    frameElem.Initialize(options.ShearStrainOption);
+                    frameElem.Initialize(options.BeamTheory);
                 }
                 else
                 {

--- a/FEALiTE2D/Structure/Structure.cs
+++ b/FEALiTE2D/Structure/Structure.cs
@@ -128,7 +128,7 @@ namespace FEALiTE2D.Structure
         public void AddElement(IElement element, StructureOption options, bool addNodes = false)
         {
             if (element == null)
-                throw new NullReferenceException($"element {element.Label} is null");
+                throw new ArgumentNullException(nameof(element), "Element cannot be null.");
 
             if (addNodes == true)
             {

--- a/FEALiTE2D/Structure/Structure.cs
+++ b/FEALiTE2D/Structure/Structure.cs
@@ -13,7 +13,7 @@ namespace FEALiTE2D.Structure
     /// To solve a structural model, the model must have at least one degree of freedom.
     /// </summary>
     [System.Serializable]
-    public class Structure
+    public partial class Structure
     {
         /// <summary>
         /// Create a new instance of <see cref="Structure"/>.
@@ -116,6 +116,17 @@ namespace FEALiTE2D.Structure
         /// <param name="addNodes">Add the nodes of the element to Nodes list?</param>
         public void AddElement(IElement element, bool addNodes = false)
         {
+            this.AddElement(element, DefaultOptions, addNodes);
+        }
+
+        /// <summary>
+        /// Adds elements to the structure.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="addNodes">Add the nodes of the element to Nodes list?</param>
+        /// <param name="options">additional options, such as shear strain</param>
+        public void AddElement(IElement element, StructureOption options, bool addNodes = false)
+        {
             if (element == null)
                 throw new NullReferenceException($"element {element.Label} is null");
 
@@ -130,12 +141,19 @@ namespace FEALiTE2D.Structure
             if (!this.Elements.Contains(element))
             {
                 this.Elements.Add(element);
-                element.Initialize();
+                if (element is FrameElement2D frameElem)
+                {
+                    frameElem.Initialize(options.ShearStrainOption);
+                }
+                else
+                {
+                    element.Initialize();
+                }
                 element.ParentStructure = this;
             }
         }
 
-        /// <summary>
+      /// <summary>
         /// Adds elements to the structure.
         /// </summary>
         /// <param name="elements">collection of elements.</param>
@@ -144,7 +162,21 @@ namespace FEALiTE2D.Structure
         {
             foreach (var item in elements)
             {
-                this.AddElement(item, addNodes);
+                this.AddElement(item, DefaultOptions, addNodes);
+            }
+        }
+
+        /// <summary>
+        /// Adds elements to the structure.
+        /// </summary>
+        /// <param name="elements">collection of elements.</param>
+        /// <param name="addNodes">Add the nodes of the element to Nodes list?</param>
+        /// <param name="options">additional options, such as shear strain</param>
+        public void AddElement(IEnumerable<IElement> elements, StructureOption options, bool addNodes = false)
+        {
+            foreach (var item in elements)
+            {
+                this.AddElement(item, options, addNodes);
             }
         }
 
@@ -231,7 +263,7 @@ namespace FEALiTE2D.Structure
             {
 
                 Console.WriteLine($" Analysis Start: {DateTime.Now}.");
-                 sw = System.Diagnostics.Stopwatch.StartNew();
+                sw = System.Diagnostics.Stopwatch.StartNew();
             }
 
             if (this.LoadCasesToRun.Count <= 0)
@@ -283,15 +315,14 @@ namespace FEALiTE2D.Structure
 
             if (detailedAnalysisOutput)
             {
-               sw.Stop();
-               Console.WriteLine($" No. of Equations: {this.nDOF}");
-               Console.WriteLine($" Analysis End Date: {DateTime.Now}.");
-               Console.WriteLine($" Analysis Took {sw.Elapsed.TotalSeconds} sec.");
+                sw.Stop();
+                Console.WriteLine($" No. of Equations: {this.nDOF}");
+                Console.WriteLine($" Analysis End Date: {DateTime.Now}.");
+                Console.WriteLine($" Analysis Took {sw.Elapsed.TotalSeconds} sec.");
             }
 
             this.Results = new PostProcessor(this);
             this.SetUpMeshingSegments();
         }
-
     }
 }

--- a/FEALiTE2D/Structure/StructureOptions.cs
+++ b/FEALiTE2D/Structure/StructureOptions.cs
@@ -1,0 +1,64 @@
+﻿using CSparse;
+using FEALiTE2D.Elements;
+using FEALiTE2D.Loads;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FEALiTE2D.Structure
+{
+    /// <summary>
+    /// Represent a structural model that has many elements connected to each other through nodes.
+    /// These elements are subjected to external actions.
+    /// To solve a structural model, the model must have at least one degree of freedom.
+    /// </summary>
+    public partial class Structure
+    {
+        /// <summary>
+        /// Structure analysis options.
+        /// </summary>
+        public class StructureOption
+        {
+            /// <summary>
+            /// Create a new instance of <see cref="StructureOption"/>.
+            /// </summary>
+            public StructureOption() { }
+
+            /// <summary>
+            /// Include shear strain in the element stiffness matrix calculation?
+            /// </summary>
+            public ShearStrainOption ShearStrainOption { get; set; } = ShearStrainOption.Without;
+        }
+
+        /// <summary>
+        /// Default structure analysis options.
+        /// </summary>
+        public static StructureOption DefaultOptions { get; } = new StructureOption();
+
+        /// <summary>
+        /// Shear strain options for frame elements.
+        /// </summary>
+        public enum ShearStrainOption
+        {
+            /// <summary>
+            /// Euler-Bernoulli beam theory (without shear strain).
+            /// </summary>
+            Without,
+
+            /// <summary>
+            /// https://hal.science/hal-01161516/document
+            /// https://fr.scribd.com/document/481185791/Timoshenko-Beam-Finite-Element-pdf?v=0.066
+            /// </summary>
+            TwoNodesTBTheory,
+
+            /// <summary>
+            /// https://hrcak.srce.hr/file/171774
+            /// </summary>
+            ModifiedTBTheory,
+
+            // To be investigated ?
+            // https://www.researchgate.net/profile/Yunhua-Luo/publication/259345479_Shear_Locking_in_Finite_Elements/links/5c86db6f299bf1e02e28586f/Shear-Locking-in-Finite-Elements.pdf?__cf_chl_rt_tk=Z.9JqauawZc8k8aYxFSouiePq1c2HWqC9GPon9ooLrY-1765990150-1.0.1.1-dWDKAP2wjbpHzLxtnyRGNB4DR46OZp_vMQ.b39RwWpc
+
+        }
+    }
+}

--- a/FEALiTE2D/Structure/StructureOptions.cs
+++ b/FEALiTE2D/Structure/StructureOptions.cs
@@ -27,7 +27,7 @@ namespace FEALiTE2D.Structure
             /// <summary>
             /// Include shear strain in the element stiffness matrix calculation?
             /// </summary>
-            public ShearStrainOption ShearStrainOption { get; set; } = ShearStrainOption.Without;
+            public BeamTheory BeamTheory { get; set; } = BeamTheory.EulerBernoulli;
         }
 
         /// <summary>
@@ -38,27 +38,17 @@ namespace FEALiTE2D.Structure
         /// <summary>
         /// Shear strain options for frame elements.
         /// </summary>
-        public enum ShearStrainOption
+        public enum BeamTheory
         {
             /// <summary>
             /// Euler-Bernoulli beam theory (without shear strain).
             /// </summary>
-            Without,
+            EulerBernoulli,
 
             /// <summary>
-            /// https://hal.science/hal-01161516/document
-            /// https://fr.scribd.com/document/481185791/Timoshenko-Beam-Finite-Element-pdf?v=0.066
+            /// Timoshenko beam theory (with shear strain).
             /// </summary>
-            TwoNodesTBTheory,
-
-            /// <summary>
-            /// https://hrcak.srce.hr/file/171774
-            /// </summary>
-            ModifiedTBTheory,
-
-            // To be investigated ?
-            // https://www.researchgate.net/profile/Yunhua-Luo/publication/259345479_Shear_Locking_in_Finite_Elements/links/5c86db6f299bf1e02e28586f/Shear-Locking-in-Finite-Elements.pdf?__cf_chl_rt_tk=Z.9JqauawZc8k8aYxFSouiePq1c2HWqC9GPon9ooLrY-1765990150-1.0.1.1-dWDKAP2wjbpHzLxtnyRGNB4DR46OZp_vMQ.b39RwWpc
-
+            Timoshenko,
         }
     }
 }


### PR DESCRIPTION
This PR adds Timoshenko beam theory support and fixes a number of bugs found during code review. I've organized the changes into 7 commits, going from the main feature down to minor fixes.

---

### Commit 1 — Timoshenko beam theory

Added full Timoshenko support alongside the existing Euler-Bernoulli model. A new `BeamTheory` enum lets you pick `EulerBernoulli` (default) or `Timoshenko` per element. The Timoshenko stiffness matrices use Φ = 12EI/(GAzL²), and the shear correction in post-processing follows v_shear = -∫(V/GAz)dx.

### Commit 2 — Timoshenko release force redistribution

`EvaluateGlobalFixedEndForces()` was using hardcoded EB coefficients (1.5, 0.5) regardless of beam theory. For Timoshenko the correct ratios are implemented. (coefficient come from the stiffness matrix, but it is preferable to hardcode them, so we do not have to build the whole matrix).

### Commit 3 — HollowTube Iz and shape function sign

Two critical bugs: `HollowTube.cs` had `this.Iy = this.Iy = ...` (Iz was never assigned, leaving it at 0 — zero bending stiffness). And `GetShapeFunctionAt` had `N8 = 1 - 4*xsi - 3*xsi2` instead of `+ 3*xsi2`.

### Commit 4 — Solver: Cholesky default, nDOF=0 support

The original code silently fell back to QR when Cholesky failed, which masks modeling errors (unstable structures get garbage results instead of an error). Now `Solve()` uses Cholesky by default and throws a clear exception on non-SPD matrices. An `allowQRFallback` parameter (default false) restores the old behavior if needed — marked as temporary.

Also fixed: a structure with all nodes fully restrained (nDOF=0) used to crash with "no sufficient degrees of freedom". This is a valid case (e.g. fixed-fixed beam) — displacements are zero, reactions are computable. Added a test for this.

### Commit 5 — Cross-section and plotting bugs

- `CircularSection`: J = 0.5*Iy was wrong (should be 2*Iy — off by 4x). J isn't used in 2D stiffness, but consumers would get the wrong torsional constant.
- `RectangularSection`: `_b / t` should be `_b / _t` in the torsion formula. When b > t, `t` is the height (not the max dimension), giving a wrong ratio.
- `Plotter.PlotStructure`: the outer `for` loop made it draw the structure N² times instead of N.
- `Structure.AddElement`: accessing `element.Label` after null check threw NullReferenceException instead of the intended error. Changed to `ArgumentNullException`.

### Commit 6 — Equality operators, labels, race condition, double-solve

- `LoadCase`, `NodalLoad`, `SupportDisplacementLoad`: `==` returned false when both sides were null. Fixed by checking `ReferenceEquals` first. `!=` was also broken for non-null vs null.
- `Plotter`: displacement diagram was labeled "Bending Moment Diagram".
- `Plotter.BoundingRectangle`: `Parallel.ForEach` was adding to a non-thread-safe `List<Vector2>`. Replaced with simple `foreach`.
- `Structure.Solve()`: calling Solve() twice threw `ArgumentException` on duplicate dictionary keys. Added `Clear()` before re-populating.
- `FrameElement2D`: removed unused `EIL`/`EIL2` variables in `EvaluateGlobalFixedEndForces`.

### Commit 7 — API typos

- `Node2D.RotaionAngle` → `RotationAngle`
- `PostProcessor.GetElementLocalFixedEndForeces` → `GetElementLocalFixedEndForces`
- `PostProcessor.GetElementGlobalFixedEndForeces` → `GetElementGlobalFixedEndForces`

These are public API names, so this is a breaking change for consumers.

---

## Breaking changes

`RotaionAngle`, `GetElementLocalFixedEndForeces`, `GetElementGlobalFixedEndForeces` are renamed. Consumers will need to update call sites.

## Tests

28 tests pass (27 original + `TestFixedFixedBeam` + `TestStructure_wShear`, minus the original shear test that was replaced).